### PR TITLE
Split the rule for linting PromQL queries in two.

### DIFF
--- a/lint/rule_panel_job_instance.go
+++ b/lint/rule_panel_job_instance.go
@@ -1,0 +1,85 @@
+package lint
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// NewPanelJobInstanceRule builds a lint rule for panels with Prometheus queries which checks
+// the query contains two matchers within every selector - `{job=~"$job", instance=~"$instance"}`
+func NewPanelJobInstanceRule() *PanelRuleFunc {
+	return &PanelRuleFunc{
+		name:        "panel-job-instance-rule",
+		description: "Checks that every PromQL query has job and instance matchers.",
+		fn: func(d Dashboard, p Panel) Result {
+			if t := getTemplateDatasource(d); t == nil || t.Query != "prometheus" {
+				// Missing template datasources is a separate rule.
+				return Result{
+					Severity: Success,
+					Message:  "OK",
+				}
+			}
+
+			if !panelHasQueries(p) {
+				return Result{
+					Severity: Success,
+					Message:  "OK",
+				}
+			}
+
+			for _, target := range p.Targets {
+				node, err := parsePromQL(target)
+				if err != nil {
+					// Invalid PromQL is another rule.
+					return Result{
+						Severity: Success,
+						Message:  "OK",
+					}
+				}
+
+				for _, selector := range parser.ExtractSelectors(node) {
+					if err := checkForMatcher(selector, "job", labels.MatchRegexp, "$job"); err != nil {
+						return Result{
+							Severity: Error,
+							Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid PromQL query '%s': %v", d.Title, p.Title, target.Expr, err),
+						}
+					}
+
+					if err := checkForMatcher(selector, "instance", labels.MatchRegexp, "$instance"); err != nil {
+						return Result{
+							Severity: Error,
+							Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid PromQL query '%s': %v", d.Title, p.Title, target.Expr, err),
+						}
+					}
+				}
+			}
+
+			return Result{
+				Severity: Success,
+				Message:  "OK",
+			}
+		},
+	}
+}
+
+func checkForMatcher(selector []*labels.Matcher, name string, ty labels.MatchType, value string) error {
+	for _, matcher := range selector {
+		if matcher.Name != name {
+			continue
+		}
+
+		if matcher.Type != ty {
+			return fmt.Errorf("%s selector is %s, not %s", name, matcher.Type, ty)
+		}
+
+		if matcher.Value != value {
+			return fmt.Errorf("%s selector is %s, not %s", name, matcher.Value, value)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("%s selector not found", name)
+}

--- a/lint/rule_panel_job_instance_test.go
+++ b/lint/rule_panel_job_instance_test.go
@@ -1,0 +1,128 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPanelJobInstanceRule(t *testing.T) {
+	linter := NewPanelJobInstanceRule()
+	dashboard := Dashboard{
+		Title: "dashboard",
+		Templating: struct {
+			List []Template `json:"list"`
+		}{
+			List: []Template{
+				{
+					Type:  "datasource",
+					Query: "prometheus",
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		result Result
+		panel  Panel
+	}{
+		// This is what a valid panel looks like.
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo{job=~"$job",instance=~"$instance"}[5m]))`,
+					},
+				},
+			},
+		},
+		// Invalid query should be fine.
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `foo(bar.baz)`,
+					},
+				},
+			},
+		},
+		// Missing job matcher
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo[5m]))': job selector not found",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo[5m]))`,
+					},
+				},
+			},
+		},
+		// Missing instance matcher
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo{job=~\"$job\"}[5m]))': instance selector not found",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo{job=~"$job"}[5m]))`,
+					},
+				},
+			},
+		},
+		// Not a regex matcher
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo{job=\"$job\",instance=\"$instance\"}[5m]))': job selector is =, not =~",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo{job="$job",instance="$instance"}[5m]))`,
+					},
+				},
+			},
+		},
+		// Wrong template variable.
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo{job=~\"$instance\",instance=~\"$job\"}[5m]))': job selector is $instance, not $job",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo{job=~"$instance",instance=~"$job"}[5m]))`,
+					},
+				},
+			},
+		},
+	} {
+		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
+	}
+}

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -48,7 +48,7 @@ func TestPanelPromQLRule(t *testing.T) {
 				Type:  "singlestat",
 				Targets: []Target{
 					{
-						Expr: `sum(rate(foo{job=~"$job",instance=~"$instance"}[5m]))`,
+						Expr: `sum(rate(foo[5m]))`,
 					},
 				},
 			},
@@ -65,70 +65,6 @@ func TestPanelPromQLRule(t *testing.T) {
 				Targets: []Target{
 					{
 						Expr: `foo(bar.baz)`,
-					},
-				},
-			},
-		},
-		// Missing job matcher
-		{
-			result: Result{
-				Severity: Error,
-				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo[5m]))': job selector not found",
-			},
-			panel: Panel{
-				Title: "panel",
-				Type:  "singlestat",
-				Targets: []Target{
-					{
-						Expr: `sum(rate(foo[5m]))`,
-					},
-				},
-			},
-		},
-		// Missing instance matcher
-		{
-			result: Result{
-				Severity: Error,
-				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo{job=~\"$job\"}[5m]))': instance selector not found",
-			},
-			panel: Panel{
-				Title: "panel",
-				Type:  "singlestat",
-				Targets: []Target{
-					{
-						Expr: `sum(rate(foo{job=~"$job"}[5m]))`,
-					},
-				},
-			},
-		},
-		// Not a regex matcher
-		{
-			result: Result{
-				Severity: Error,
-				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo{job=\"$job\",instance=\"$instance\"}[5m]))': job selector is =, not =~",
-			},
-			panel: Panel{
-				Title: "panel",
-				Type:  "singlestat",
-				Targets: []Target{
-					{
-						Expr: `sum(rate(foo{job="$job",instance="$instance"}[5m]))`,
-					},
-				},
-			},
-		},
-		// Wrong template variable.
-		{
-			result: Result{
-				Severity: Error,
-				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(rate(foo{job=~\"$instance\",instance=~\"$job\"}[5m]))': job selector is $instance, not $job",
-			},
-			panel: Panel{
-				Title: "panel",
-				Type:  "singlestat",
-				Targets: []Target{
-					{
-						Expr: `sum(rate(foo{job=~"$instance",instance=~"$job"}[5m]))`,
 					},
 				},
 			},

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -59,6 +59,7 @@ func NewRuleSet() RuleSet {
 			NewPanelDatasourceRule(),
 			NewPanelPromQLRule(),
 			NewPanelRateIntervalRule(),
+			NewPanelJobInstanceRule(),
 		},
 	}
 }


### PR DESCRIPTION
This is so we can optionally skip the job and instance label whilst still validating PromQL queries.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>