### PR TITLE
Simplify the substitution for $__rate_interval and support $__range  etc.

### DIFF
--- a/lint/rule_panel_promql.go
+++ b/lint/rule_panel_promql.go
@@ -29,10 +29,12 @@ func parsePromQL(t Target) (parser.Expr, error) {
 		variable     string
 		replacesment string
 	}{
-		{"$__range_s", "18000"},
-		{"$__range_ms", "18000000"},
-		{"$__range", "5m"},
-		{"$__rate_interval", "5m"},
+		{"$__rate_interval", "8869990787ms"},
+		{"$__interval", "4867856611ms"},
+		{"$__interval_ms", "7781188786"},
+		{"$__range_ms", "6737667980"},
+		{"$__range_s", "9397795485"},
+		{"$__range", "6069770749ms"},
 	} {
 		expr = strings.ReplaceAll(expr, pattern.variable, pattern.replacesment)
 	}

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -69,6 +69,22 @@ func TestPanelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Variable substitutions
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo[$__rate_interval])) * $__range_s`,
+					},
+				},
+			},
+		},
 	} {
 		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
 	}

--- a/lint/rule_panel_rate_interval.go
+++ b/lint/rule_panel_rate_interval.go
@@ -2,7 +2,10 @@ package lint
 
 import (
 	"fmt"
+	"regexp"
 )
+
+var rangeVectorRegexp = regexp.MustCompile(`\[([^:]+)\]`)
 
 // NewPanelRateIntervalRule builds a lint rule for panels with Prometheus queries which checks
 // all range vector selectors use $__rate_interval.


### PR DESCRIPTION
We're failing on queries like `avg(foo) * $__range_s` and shouldn't be.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>