### PR TITLE
Honor ResultSet configuration more seamlessly

### DIFF
--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -106,6 +106,30 @@ func TestResultSet(t *testing.T) {
 		require.Len(t, byRule["rule1"], 1)
 		require.Len(t, byRule["rule2"], 1)
 	})
+
+	t.Run("Honors Configuration given config present before results added", func(t *testing.T) {
+		c := NewConfigurationFile()
+		appendConfigExclude(t, "rule1", "", "", "", c)
+
+		r := ResultSet{}
+		r.Configure(c)
+		r.AddResult(newResultContext(t, "rule1", "", "", "", Error))
+
+		require.Equal(t, Exclude, r.MaximumSeverity())
+		require.Equal(t, Exclude, r.ByRule()["rule1"][0].Result.Severity)
+	})
+
+	t.Run("Honors Configuration given config added after results added", func(t *testing.T) {
+		c := NewConfigurationFile()
+		appendConfigExclude(t, "rule1", "", "", "", c)
+
+		r := ResultSet{}
+		r.AddResult(newResultContext(t, "rule1", "", "", "", Error))
+		r.Configure(c)
+
+		require.Equal(t, Exclude, r.MaximumSeverity())
+		require.Equal(t, Exclude, r.ByRule()["rule1"][0].Result.Severity)
+	})
 }
 
 func TestConfiguration(t *testing.T) {

--- a/lint/results.go
+++ b/lint/results.go
@@ -39,10 +39,25 @@ func (r ResultContext) TtyPrint() {
 
 type ResultSet struct {
 	results []ResultContext
+	config  *ConfigurationFile
 }
 
+// Configure adds, and applies the provided configuration to all results currently in the ResultSet
+func (rs *ResultSet) Configure(c *ConfigurationFile) {
+	rs.config = c
+	for i := range rs.results {
+		rs.results[i] = rs.config.Apply(rs.results[i])
+	}
+}
+
+// AddResult adds a result to the ResultSet, applying the current configuration if set
 func (rs *ResultSet) AddResult(r ResultContext) {
-	rs.results = append(rs.results, r)
+	if rs.config != nil {
+		rs.results = append(rs.results, rs.config.Apply(r))
+	} else {
+		rs.results = append(rs.results, r)
+	}
+
 }
 
 func (rs *ResultSet) MaximumSeverity() Severity {
@@ -68,11 +83,11 @@ func (rs *ResultSet) ByRule() map[string][]ResultContext {
 	return ret
 }
 
-func (rs *ResultSet) ReportByRule(config *ConfigurationFile) {
+func (rs *ResultSet) ReportByRule() {
 	for _, res := range rs.ByRule() {
 		fmt.Println(res[0].Rule.Description())
 		for _, r := range res {
-			config.Apply(r).TtyPrint()
+			r.TtyPrint()
 		}
 	}
 }

--- a/lint/results.go
+++ b/lint/results.go
@@ -53,11 +53,9 @@ func (rs *ResultSet) Configure(c *ConfigurationFile) {
 // AddResult adds a result to the ResultSet, applying the current configuration if set
 func (rs *ResultSet) AddResult(r ResultContext) {
 	if rs.config != nil {
-		rs.results = append(rs.results, rs.config.Apply(r))
-	} else {
-		rs.results = append(rs.results, r)
+	        r = rs.config.Apply(r)
 	}
-
+	rs.results = append(rs.results, r)
 }
 
 func (rs *ResultSet) MaximumSeverity() Severity {

--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ var lintCmd = &cobra.Command{
 			return fmt.Errorf("failed to lint dashboard: %v", err)
 		}
 
-		results.ReportByRule(config)
+		results.Configure(config)
+		results.ReportByRule()
 
 		if lintStrictFlag && results.MaximumSeverity() >= lint.Warning {
 			return fmt.Errorf("there were linting errors, please see previous output")


### PR DESCRIPTION
This PR makes applying configuration more seamless. Namely, if a ConfigurationFile is added to a ResultSet before or after it contains results, that configuration is automatically applied.

That ensures that any downstream reporting reflects the current state of results, with the config applied.