### PR TITLE
handle multiple [] in expr

### DIFF
--- a/lint/rule_panel_rate_interval.go
+++ b/lint/rule_panel_rate_interval.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-var rangeVectorRegexp = regexp.MustCompile(`\[([^:]+)\]`)
+var rangeVectorRegexp = regexp.MustCompile(`\[([^:)]+)\]`)
 
 // NewPanelRateIntervalRule builds a lint rule for panels with Prometheus queries which checks
 // all range vector selectors use $__rate_interval.

--- a/lint/rule_panel_rate_interval_test.go
+++ b/lint/rule_panel_rate_interval_test.go
@@ -53,6 +53,22 @@ func TestPanelRateIntervalRule(t *testing.T) {
 				},
 			},
 		},
+                // This is what a valid panel looks like.
+                {
+                        result: Result{
+                                Severity: Success,
+                                Message:  "OK",
+                        },
+                        panel: Panel{
+                                Title: "panel",
+                                Type:  "singlestat",
+                                Targets: []Target{
+                                        {
+                                                Expr: `sum(rate(foo{job=~"$job",instance=~"$instance"}[$__rate_interval]))/sum(rate(bar{job=~"$job",instance=~"$instance"}[$__rate_interval]))`,
+                                        },
+                                },
+                        },
+                },
 		// Invalid query
 		{
 			result: Result{


### PR DESCRIPTION
the current regex `\[([^:]+)\]` returns `[$__rate_interval]))/sum(rate(bar{job=~"$job",instance=~"$instance"}[$__rate_interval]` for this original regex `sum(rate(foo{job=~"$job",instance=~"$instance"}[$__rate_interval]))/sum(rate(bar{job=~"$job",instance=~"$instance"}[$__rate_interval]))`

replace `\[([^:]+)\]` with `\[([^):]+)\]` to fix this issue.

Signed-off-by: clyang82 <chuyang@redhat.com>