### PR TITLE
Add timeseries to list of panel types when checking datasource

### DIFF
--- a/lint/rule_panel_datasource.go
+++ b/lint/rule_panel_datasource.go
@@ -11,7 +11,7 @@ func NewPanelDatasourceRule() *PanelRuleFunc {
 		fn: func(d Dashboard, p Panel) Result {
 
 			switch p.Type {
-			case "singlestat", "graph", "table":
+			case "singlestat", "graph", "table", "timeseries":
 				if p.Datasource != "$datasource" && p.Datasource != "${datasource}" {
 					return Result{
 						Severity: Error,


### PR DESCRIPTION
The panel-datasource rule is hyper specific about which panel types it checks. Is this desirable?

I added timeseries, since I was reviewing a dashboard which used it. But.. Should this be filtered at all by type?