### PR TITLE
Support grafana variables in template variables

### DIFF
--- a/lint/rule_panel_job_instance.go
+++ b/lint/rule_panel_job_instance.go
@@ -30,7 +30,7 @@ func NewPanelJobInstanceRule() *PanelRuleFunc {
 			}
 
 			for _, target := range p.Targets {
-				node, err := parsePromQL(target)
+				node, err := parsePromQL(target.Expr)
 				if err != nil {
 					// Invalid PromQL is another rule.
 					return Result{

--- a/lint/rule_panel_promql.go
+++ b/lint/rule_panel_promql.go
@@ -2,7 +2,6 @@ package lint
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -24,28 +23,7 @@ func panelHasQueries(p Panel) bool {
 // replacing eg [$__rate_interval] with [5m] so queries parse correctly.
 // We also replace various other Grafana global variables.
 func parsePromQL(expr string) (parser.Expr, error) {
-	replacements := make([]string, 0, 37)
-	for _, pattern := range []struct {
-		variable    string
-		replacement string
-	}{
-		{"__rate_interval", "8869990787ms"},
-		{"__interval", "4867856611ms"},
-		{"__interval_ms", "7781188786"},
-		{"__range_ms", "6737667980"},
-		{"__range_s", "9397795485"},
-		{"__range", "6069770749ms"},
-	} {
-		replacements = append(
-			replacements,
-			[]string{
-				"$" + pattern.variable, pattern.replacement,
-				"${" + pattern.variable + "}", pattern.replacement,
-				"[[" + pattern.variable + "]]", pattern.replacement,
-			}...,
-		)
-	}
-	return parser.ParseExpr(strings.NewReplacer(replacements...).Replace(expr))
+	return parser.ParseExpr(expandVariables(expr))
 }
 
 // NewPanelPromQLRule builds a lint rule for panels with Prometheus queries which checks:

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -85,6 +85,38 @@ func TestPanelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Variable substitutions with ${...}
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo[$__rate_interval])) * ${__range_s}`,
+					},
+				},
+			},
+		},
+		// Variable substitutions with [[...]]
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo[$__rate_interval])) * [[__range_s]]`,
+					},
+				},
+			},
+		},
 	} {
 		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
 	}

--- a/lint/rule_template_label_promql.go
+++ b/lint/rule_template_label_promql.go
@@ -3,8 +3,6 @@ package lint
 import (
 	"fmt"
 	"regexp"
-
-	"github.com/prometheus/prometheus/promql/parser"
 )
 
 var templatedLabelRegexp = regexp.MustCompile(`([a-z_]+)\((.+)\)`)
@@ -34,7 +32,7 @@ func parseTemplatedLabelPromQL(t Template) error {
 	if !labelHasValidDataSourceFunction(tokens[1]) {
 		return fmt.Errorf("invalid 'function': %v", tokens[1])
 	}
-	expr, err := parser.ParseExpr(tokens[2])
+	expr, err := parsePromQL(tokens[2])
 	if expr != nil {
 		return nil
 	}

--- a/lint/rule_template_label_promql_test.go
+++ b/lint/rule_template_label_promql_test.go
@@ -141,6 +141,33 @@ func TestTemplateLabelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Support main grafana variables.
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Query: "prometheus",
+						},
+						{
+							Name:       "namespaces",
+							Datasource: "$datasource",
+							Query:      "query_result(max by(namespaces) (max_over_time(memory{}[$__range])))",
+							Type:       "query",
+							Label:      "job",
+						},
+					},
+				},
+			},
+		},
 	} {
 		require.Equal(t, tc.result, linter.LintDashboard(tc.dashboard))
 	}

--- a/lint/variables.go
+++ b/lint/variables.go
@@ -1,0 +1,80 @@
+package lint
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	stateInit = iota
+	stateQuotedString
+	stateVariable
+	stateVariableCurly
+	stateVariableSquareFirst
+	stateVariableSquare
+	stateError
+)
+
+// https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/
+var globalVariables = map[string]interface{}{
+	"__rate_interval": 8869990787 * time.Millisecond,
+	"__interval":      4867856611 * time.Millisecond,
+	"__interval_ms":   7781188786,
+	"__range_ms":      6737667980,
+	"__range_s":       9397795485,
+	"__range":         6069770749 * time.Millisecond,
+	"__dashboard":     "AwREbnft",
+	"__from":          time.Date(2020, 7, 13, 20, 19, 9, 254000000, time.UTC),
+	"__to":            time.Date(2020, 7, 13, 20, 19, 9, 254000000, time.UTC),
+	"__name":          "name",
+	"__org":           42,
+	"__org.name":      "orgname",
+	"__user.id":       42,
+	"__user.login":    "user",
+	"__user.email":    "user@test.com",
+	"timeFilter":      "time > now() - 7d",
+	"__timeFilter":    "time > now() - 7d",
+}
+
+func expandVariables(expr string) string {
+	out := make([]rune, 0, len(expr))
+	state := stateInit // init
+	for _, c := range expr {
+		if state == -1 {
+			return ""
+		}
+		fmt.Println(string(c), state)
+		switch c {
+		case '$':
+			switch state {
+			case stateInit:
+				state = stateVariable
+			default:
+				state = stateError
+			}
+		case '"':
+			switch state {
+			case stateInit:
+				state = stateQuotedString
+			case stateQuotedString:
+				state = stateInit
+			}
+			out = append(out, c)
+		case '{':
+			switch state {
+			case stateInit:
+				state = stateVariableCurly
+			}
+		case '}':
+			switch state {
+			case stateVariableCurly:
+				state = stateInit
+			}
+		default:
+			if state == stateInit || state == stateQuotedString {
+				out = append(out, c)
+			}
+		}
+	}
+	return string(out)
+}

--- a/lint/variables_test.go
+++ b/lint/variables_test.go
@@ -1,0 +1,19 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariableExpansion(t *testing.T) {
+	for _, tc := range []struct {
+		desc   string
+		expr   string
+		result string
+	}{
+		{"Should not replace variables in quoted strings", "label_values(up{job=~\"$job\"}, namespace)", "label_values(up{job=~\"$job\"}, namespace)"},
+	} {
+		require.Equal(t, tc.result, expandVariables(tc.expr))
+	}
+}


### PR DESCRIPTION
 Hello,

I noticed that template-label-promql-rule fails on usage of $__range grafana variable, which should be supported according to https://grafana.com/docs/grafana/latest/datasources/prometheus/#using-interval-and-range-variables

I also propose to implement all the syntaxes documented here: https://grafana.com/docs/grafana/latest/datasources/prometheus/#using-variables-in-queries

Gabriel