### PR TITLE
Support most of the grafana variables in promQL queries

### DIFF
--- a/lint/rule_panel_job_instance.go
+++ b/lint/rule_panel_job_instance.go
@@ -30,7 +30,7 @@ func NewPanelJobInstanceRule() *PanelRuleFunc {
 			}
 
 			for _, target := range p.Targets {
-				node, err := parsePromQL(target)
+				node, err := parsePromQL(target.Expr)
 				if err != nil {
 					// Invalid PromQL is another rule.
 					return Result{

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -85,6 +85,38 @@ func TestPanelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Variable substitutions with ${...}
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(rate(foo[$__rate_interval])) * ${__range_s}`,
+					},
+				},
+			},
+		},
+		// Variable substitutions inside by clause
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum by(${variable:csv}) (rate(foo[$__rate_interval])) * $__range_s`,
+					},
+				},
+			},
+		},
 	} {
 		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
 	}

--- a/lint/rule_template_label_promql.go
+++ b/lint/rule_template_label_promql.go
@@ -3,8 +3,6 @@ package lint
 import (
 	"fmt"
 	"regexp"
-
-	"github.com/prometheus/prometheus/promql/parser"
 )
 
 var templatedLabelRegexp = regexp.MustCompile(`([a-z_]+)\((.+)\)`)
@@ -34,7 +32,7 @@ func parseTemplatedLabelPromQL(t Template) error {
 	if !labelHasValidDataSourceFunction(tokens[1]) {
 		return fmt.Errorf("invalid 'function': %v", tokens[1])
 	}
-	expr, err := parser.ParseExpr(tokens[2])
+	expr, err := parsePromQL(tokens[2])
 	if expr != nil {
 		return nil
 	}

--- a/lint/rule_template_label_promql_test.go
+++ b/lint/rule_template_label_promql_test.go
@@ -141,6 +141,33 @@ func TestTemplateLabelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Support main grafana variables.
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Query: "prometheus",
+						},
+						{
+							Name:       "namespaces",
+							Datasource: "$datasource",
+							Query:      "query_result(max by(namespaces) (max_over_time(memory{}[$__range])))",
+							Type:       "query",
+							Label:      "job",
+						},
+					},
+				},
+			},
+		},
 	} {
 		require.Equal(t, tc.result, linter.LintDashboard(tc.dashboard))
 	}

--- a/lint/variables.go
+++ b/lint/variables.go
@@ -1,0 +1,176 @@
+package lint
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/
+var globalVariables = map[string]interface{}{
+	"__rate_interval": "8869990787ms",
+	"__interval":      "4867856611ms",
+	"__interval_ms":   "7781188786",
+	"__range_ms":      "6737667980",
+	"__range_s":       "9397795485",
+	"__range":         "6069770749ms",
+	"__dashboard":     "AwREbnft",
+	"__from":          time.Date(2020, 7, 13, 20, 19, 9, 254000000, time.UTC),
+	"__to":            time.Date(2020, 7, 13, 20, 19, 9, 254000000, time.UTC),
+	"__name":          "name",
+	"__org":           42,
+	"__org.name":      "orgname",
+	"__user.id":       42,
+	"__user.login":    "user",
+	"__user.email":    "user@test.com",
+	"timeFilter":      "time > now() - 7d",
+	"__timeFilter":    "time > now() - 7d",
+}
+
+func stringValue(name string, value interface{}, kind, format string) (string, error) {
+	switch val := value.(type) {
+	case int:
+		return strconv.Itoa(val), nil
+	case time.Time:
+		// Implements https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/#__from-and-__to
+		switch kind {
+		case "date":
+			switch format {
+			case "seconds":
+				return strconv.FormatInt(val.Unix(), 10), nil
+			case "iso":
+				return val.Format(time.RFC3339), nil
+			default:
+				return "", fmt.Errorf("Unsupported momentjs time format: " + format)
+			}
+		default:
+			switch format {
+			case "date":
+				return val.Format(time.RFC3339), nil
+			default:
+				return strconv.FormatInt(val.UnixMilli(), 10), nil
+			}
+		}
+	default:
+		// Use variable name as sample value
+		svalue := fmt.Sprintf("%s", value)
+		// For list types, repeat it 3 times (arbitrary value)
+		svalueList := []string{svalue, svalue, svalue}
+		// Implements https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/
+		switch format {
+		case "csv":
+			return strings.Join(svalueList, ","), nil
+		case "doublequote":
+			return "\"" + strings.Join(svalueList, "\",\"") + "\"", nil
+		case "glob":
+			return "{" + strings.Join(svalueList, ",") + "}", nil
+		case "json":
+			data, err := json.Marshal(svalueList)
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		case "lucene":
+			return "(\"" + strings.Join(svalueList, "\" OR \"") + "\")", nil
+		case "percentencode":
+			return url.QueryEscape(strings.Join(svalueList, ",")), nil
+		case "pipe":
+			return strings.Join(svalueList, "|"), nil
+		case "raw":
+			return strings.Join(svalueList, ","), nil
+		case "regex":
+			return strings.Join(svalueList, "|"), nil
+		case "singlequote":
+			return "'" + strings.Join(svalueList, "','") + "'", nil
+		case "sqlstring":
+			return "'" + strings.Join(svalueList, "','") + "'", nil
+		case "text":
+			return strings.Join(svalueList, " + "), nil
+		case "queryparam":
+			values := url.Values{}
+			for _, svalue := range svalueList {
+				values.Add("var-"+name, svalue)
+			}
+			return values.Encode(), nil
+		default:
+			return svalue, nil
+		}
+	}
+}
+
+func variableSampleValue(s string) (string, error) {
+	var name, kind, format string
+	parts := strings.Split(s, ":")
+	switch len(parts) {
+	case 1:
+		// No format
+		name = s
+	case 2:
+		// Could be __from:date, variable:csv, ...
+		name = parts[0]
+		format = parts[1]
+	case 3:
+		// Could be __from:date:iso, ...
+		name = parts[0]
+		kind = parts[1]
+		format = parts[2]
+	default:
+		return "", fmt.Errorf("Unknown variable format: %s", s)
+	}
+	// If it is part of the globals, return a string representation of a sample value
+	if value, ok := globalVariables[name]; ok {
+		return stringValue(name, value, kind, format)
+	}
+	// Assume variable type is a string
+	return stringValue(name, name, kind, format)
+}
+
+var variableRegexp = regexp.MustCompile(
+	strings.Join([]string{
+		`\$([[:word:]]+)`,    // $var syntax
+		`\$\{([^}]+)\}`,      // ${var} syntax
+		`\[\[([^\[\]]+)\]\]`, // [[var]] syntax
+	}, "|"),
+)
+
+func expandVariables(expr string) (string, error) {
+	parts := strings.Split(expr, "\"")
+	for i, part := range parts {
+		if i%2 == 1 {
+			// Inside a double quote string, just add it
+			continue
+		}
+
+		// Accumulator to store the processed submatches
+		var subparts []string
+		// Cursor indicates where we are in the part being processed
+		cursor := 0
+		for _, v := range variableRegexp.FindAllStringSubmatchIndex(part, -1) {
+			// Add all until match starts
+			subparts = append(subparts, part[cursor:v[0]])
+			// Iterate on all the subgroups and find the one that matched
+			for j := 2; j < len(v); j += 2 {
+				if v[j] < 0 {
+					continue
+				}
+				// Replace the match with sample value
+				val, err := variableSampleValue(part[v[j]:v[j+1]])
+				if err != nil {
+					return "", err
+				}
+				subparts = append(subparts, val)
+			}
+			// Move the start cursor at the end of the current match
+			cursor = v[1]
+		}
+		// Add rest of the string
+		subparts = append(subparts, parts[i][cursor:])
+		// Merge all back into the parts
+		parts[i] = strings.Join(subparts, "")
+	}
+	return strings.Join(parts, "\""), nil
+}

--- a/lint/variables_test.go
+++ b/lint/variables_test.go
@@ -1,0 +1,150 @@
+package lint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariableExpansion(t *testing.T) {
+	for _, tc := range []struct {
+		desc   string
+		expr   string
+		result string
+		err    error
+	}{
+		{
+			desc:   "Should not replace variables in quoted strings",
+			expr:   "up{job=~\"$job\"}",
+			result: "up{job=~\"$job\"}",
+		},
+		// https://grafana.com/docs/grafana/latest/variables/syntax/
+		{
+			desc:   "Should replace variables in metric name",
+			expr:   "up$var{job=~\"$job\"}",
+			result: "upvar{job=~\"$job\"}",
+		},
+		{
+			desc:   "Should replace global rate/range variables",
+			expr:   "rate(metric{}[$__rate_interval])",
+			result: "rate(metric{}[8869990787ms])",
+		},
+		{
+			desc:   "Should support ${...} syntax",
+			expr:   "rate(metric{}[${__rate_interval}])",
+			result: "rate(metric{}[8869990787ms])",
+		},
+		{
+			desc:   "Should support [[...]] syntax",
+			expr:   "rate(metric{}[[[__rate_interval]]])",
+			result: "rate(metric{}[8869990787ms])",
+		},
+		// https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/
+		{
+			desc:   "Should support ${__user.id}",
+			expr:   "sum(http_requests_total{method=\"GET\"} @ ${__user.id})",
+			result: "sum(http_requests_total{method=\"GET\"} @ 42)",
+		},
+		{
+			desc:   "Should support $__from/$__to",
+			expr:   "sum(http_requests_total{method=\"GET\"} @ $__from)",
+			result: "sum(http_requests_total{method=\"GET\"} @ 1594671549254)",
+		},
+		{
+			desc:   "Should support $__from/$__to with formatting option (unix seconds)",
+			expr:   "sum(http_requests_total{method=\"GET\"} @ ${__from:date:seconds}000)",
+			result: "sum(http_requests_total{method=\"GET\"} @ 1594671549000)",
+		},
+		{
+			desc:   "Should support $__from/$__to with formatting option (iso default)",
+			expr:   "sum(http_requests_total{method=\"GET\"} @ ${__from:date})",
+			result: "sum(http_requests_total{method=\"GET\"} @ 2020-07-13T20:19:09Z)",
+		},
+		{
+			desc:   "Should support $__from/$__to with formatting option (iso)",
+			expr:   "sum(http_requests_total{method=\"GET\"} @ ${__from:date:iso})",
+			result: "sum(http_requests_total{method=\"GET\"} @ 2020-07-13T20:19:09Z)",
+		},
+		{
+			desc: "Should not support $__from/$__to with momentjs formatting option (iso)",
+			expr: "sum(http_requests_total{method=\"GET\"} @ ${__from:date:YYYY-MM})",
+			err:  fmt.Errorf("Unsupported momentjs time format: YYYY-MM"),
+		},
+		// https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/
+		{
+			desc:   "Should support ${variable:csv} syntax",
+			expr:   "max by(${variable:csv}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(variable,variable,variable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:doublequote} syntax",
+			expr:   "max by(${variable:doublequote}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(\"variable\",\"variable\",\"variable\") (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:glob} syntax",
+			expr:   "max by(${variable:glob}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by({variable,variable,variable}) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:json} syntax",
+			expr:   "max by(${variable:json}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by([\"variable\",\"variable\",\"variable\"]) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:lucene} syntax",
+			expr:   "max by(${variable:lucene}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by((\"variable\" OR \"variable\" OR \"variable\")) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:percentencode} syntax",
+			expr:   "max by(${variable:percentencode}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(variable%2Cvariable%2Cvariable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:pipe} syntax",
+			expr:   "max by(${variable:pipe}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(variable|variable|variable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:raw} syntax",
+			expr:   "max by(${variable:raw}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(variable,variable,variable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:regex} syntax",
+			expr:   "max by(${variable:regex}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(variable|variable|variable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:singlequote} syntax",
+			expr:   "max by(${variable:singlequote}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by('variable','variable','variable') (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:sqlstring} syntax",
+			expr:   "max by(${variable:sqlstring}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by('variable','variable','variable') (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:text} syntax",
+			expr:   "max by(${variable:text}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(variable + variable + variable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc:   "Should support ${variable:queryparam} syntax",
+			expr:   "max by(${variable:queryparam}) (rate(cpu{}[$__rate_interval]))",
+			result: "max by(var-variable=variable&var-variable=variable&var-variable=variable) (rate(cpu{}[8869990787ms]))",
+		},
+		{
+			desc: "Should return an error for unknown syntax",
+			expr: "max by(${a:b:c:d}) (rate(cpu{}[$__rate_interval]))",
+			err:  fmt.Errorf("Unknown variable format: a:b:c:d"),
+		},
+	} {
+		s, err := expandVariables(tc.expr)
+		require.Equal(t, tc.err, err)
+		require.Equal(t, tc.result, s, tc.desc)
+	}
+}


### PR DESCRIPTION
Hello,

I hope the code and the tests are self-explanatory. The idea is to support most of the variable behavior documented on the grafana documentation. Ultimately, what I *really* need to be able to replace my own in-house linter, is to support this syntax: `sum by(${variable:csv}) (up{})`. I just took the opportunity to support most of the documentation (I just have no clue about the TSDB format).

Some notes:

- I did not implement the momentjs dates formatting as it was going beyond simple use of the Go standard library
- This could be relatively extended to validate all the variables used are defined as template variable (and also spot unused template variables), which I would see as very helpful.

Of course, I will monitor any question/comments and do my best to be very reactive.

Gabriel