### PR TITLE
Allow template variable substitution in panel promql

### DIFF
--- a/lint/rule_panel_promql.go
+++ b/lint/rule_panel_promql.go
@@ -2,10 +2,13 @@ package lint
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/prometheus/promql/parser"
 )
+
+var rangeVectorRegex = regexp.MustCompile(`\[(.+)\]`)
 
 // panelHasQueries returns true is the panel has queries we should try and
 // validate.  We allow-list panels here to prevent false positives with
@@ -38,6 +41,7 @@ func parsePromQL(t Target) (parser.Expr, error) {
 	} {
 		expr = strings.ReplaceAll(expr, pattern.variable, pattern.replacesment)
 	}
+	expr = rangeVectorRegex.ReplaceAllString(expr, "[5000m]")
 	return parser.ParseExpr(expr)
 }
 

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -85,6 +85,22 @@ func TestPanelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Grafana variable substitutions
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `rate(http_requests_total[$interval:$resolution])`,
+					},
+				},
+			},
+		},
 	} {
 		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
 	}


### PR DESCRIPTION
As mentioned in the $title, this PR enables templated variable substitution in panel promql expressions.

Example: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/dashboards/network-usage/cluster-total.libsonnet#L395

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>