### PR TITLE
Use template variables to expand variables in promQL expressions

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -18,13 +18,25 @@ const (
 // Target is a deliberately incomplete representation of the Dashboard -> Template type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Template struct {
-	Name       string     `json:"name"`
-	Label      string     `json:"label"`
-	Type       string     `json:"type"`
-	Query      string     `json:"query"`
-	Datasource Datasource `json:"datasource"`
-	Multi      bool       `json:"multi"`
-	AllValue   string     `json:"allValue"`
+	Name       string           `json:"name"`
+	Label      string           `json:"label"`
+	Type       string           `json:"type"`
+	Query      string           `json:"query"`
+	Datasource Datasource       `json:"datasource"`
+	Multi      bool             `json:"multi"`
+	AllValue   string           `json:"allValue"`
+	Current    TemplateValue    `json:"current"`
+	Options    []TemplateOption `json:"options"`
+}
+
+type TemplateValue struct {
+	Text  string `json:"text"`
+	Value string `json:"value"`
+}
+
+type TemplateOption struct {
+	TemplateValue
+	Selected bool `json:"selected"`
 }
 
 func (t *Template) UnmarshalJSON(buf []byte) error {

--- a/lint/rule_panel_job_instance.go
+++ b/lint/rule_panel_job_instance.go
@@ -30,7 +30,7 @@ func NewPanelJobInstanceRule() *PanelRuleFunc {
 			}
 
 			for _, target := range p.Targets {
-				node, err := parsePromQL(target.Expr)
+				node, err := parsePromQL(target.Expr, d.Templating.List)
 				if err != nil {
 					// Invalid PromQL is another rule.
 					return Result{

--- a/lint/rule_panel_promql.go
+++ b/lint/rule_panel_promql.go
@@ -22,8 +22,8 @@ func panelHasQueries(p Panel) bool {
 // parsePromQL returns the parsed PromQL statement from a panel,
 // replacing eg [$__rate_interval] with [5m] so queries parse correctly.
 // We also replace various other Grafana global variables.
-func parsePromQL(expr string) (parser.Expr, error) {
-	expr, err := expandVariables(expr)
+func parsePromQL(expr string, variables []Template) (parser.Expr, error) {
+	expr, err := expandVariables(expr, variables)
 	if err != nil {
 		return nil, fmt.Errorf("could not expand variables: %w", err)
 	}
@@ -54,7 +54,7 @@ func NewPanelPromQLRule() *PanelRuleFunc {
 			}
 
 			for _, target := range p.Targets {
-				if _, err := parsePromQL(target.Expr); err != nil {
+				if _, err := parsePromQL(target.Expr, d.Templating.List); err != nil {
 					return Result{
 						Severity: Error,
 						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid PromQL query '%s': %v", d.Title, p.Title, target.Expr, err),

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -118,6 +118,22 @@ func TestPanelPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Template variables substitutions
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum (rate(foo[$interval:$resolution]))`,
+					},
+				},
+			},
+		},
 	} {
 		dashboard := Dashboard{
 			Title: "dashboard",
@@ -128,6 +144,21 @@ func TestPanelPromQLRule(t *testing.T) {
 					{
 						Type:  "datasource",
 						Query: "prometheus",
+					},
+					{
+						Type: "interval",
+						Name: "interval",
+						Options: []TemplateOption{
+							{TemplateValue: TemplateValue{Value: "1h"}, Selected: true},
+						},
+					},
+					{
+						Type: "resolution",
+						Name: "resolution",
+						Options: []TemplateOption{
+							{TemplateValue: TemplateValue{Value: "1h"}, Selected: true},
+							{TemplateValue: TemplateValue{Value: "1h"}},
+						},
 					},
 				},
 			},

--- a/lint/rule_template_label_promql.go
+++ b/lint/rule_template_label_promql.go
@@ -21,7 +21,7 @@ func labelHasValidDataSourceFunction(name string) bool {
 // parseTemplatedLabelPromQL returns error in case
 // 1) The given PromQL expressions is invalid
 // 2) Use of invalid label function
-func parseTemplatedLabelPromQL(t Template) error {
+func parseTemplatedLabelPromQL(t Template, variables []Template) error {
 	// regex capture must return slice of 3 strings.
 	// 1) given query 2) function name 3) function arg.
 	tokens := templatedLabelRegexp.FindStringSubmatch(t.Query)
@@ -32,7 +32,7 @@ func parseTemplatedLabelPromQL(t Template) error {
 	if !labelHasValidDataSourceFunction(tokens[1]) {
 		return fmt.Errorf("invalid 'function': %v", tokens[1])
 	}
-	expr, err := parsePromQL(tokens[2])
+	expr, err := parsePromQL(tokens[2], variables)
 	if expr != nil {
 		return nil
 	}
@@ -55,7 +55,7 @@ func NewTemplateLabelPromQLRule() *DashboardRuleFunc {
 				if template.Type != "query" {
 					continue
 				}
-				if err := parseTemplatedLabelPromQL(template); err != nil {
+				if err := parseTemplatedLabelPromQL(template, d.Templating.List); err != nil {
 					return Result{
 						Severity: Error,
 						Message:  fmt.Sprintf("Dashboard '%s', template '%s' invalid templated label '%s': %v", d.Title, template.Name, template.Query, err),


### PR DESCRIPTION
Another solution to the problem shared in https://github.com/grafana/dashboard-linter/pull/18
Tested successfully on the HEAD of https://github.com/kubernetes-monitoring/kubernetes-mixin.git (removing the `sed` line in the Makefile)
@tomwilkie  @arajkumar 