### PR TITLE
Add the possibility to add custom rules implemented in Go

### DIFF
--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 type TestRule struct {
+	Rule
 	name string
 }
 

--- a/lint/rule_panel_datasource_test.go
+++ b/lint/rule_panel_datasource_test.go
@@ -35,6 +35,15 @@ func TestPanelDatasource(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintPanel(Dashboard{Title: "test"}, tc.panel))
+		testRule(t, linter, Dashboard{Title: "test", Panels: []Panel{tc.panel}}, tc.result)
 	}
+}
+
+// testRule is a small helper that tests a lint rule and expects it to only return
+// a single result.
+func testRule(t *testing.T, rule Rule, d Dashboard, result Result) {
+	var rs ResultSet
+	rule.Lint(d, &rs)
+	require.Len(t, rs.results, 1)
+	require.Equal(t, result, rs.results[0].Result)
 }

--- a/lint/rule_panel_job_instance_test.go
+++ b/lint/rule_panel_job_instance_test.go
@@ -2,25 +2,10 @@ package lint
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestPanelJobInstanceRule(t *testing.T) {
 	linter := NewPanelJobInstanceRule()
-	dashboard := Dashboard{
-		Title: "dashboard",
-		Templating: struct {
-			List []Template `json:"list"`
-		}{
-			List: []Template{
-				{
-					Type:  "datasource",
-					Query: "prometheus",
-				},
-			},
-		},
-	}
 
 	for _, tc := range []struct {
 		result Result
@@ -123,6 +108,21 @@ func TestPanelJobInstanceRule(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
+		dashboard := Dashboard{
+			Title: "dashboard",
+			Templating: struct {
+				List []Template `json:"list"`
+			}{
+				List: []Template{
+					{
+						Type:  "datasource",
+						Query: "prometheus",
+					},
+				},
+			},
+			Panels: []Panel{tc.panel},
+		}
+
+		testRule(t, linter, dashboard, tc.result)
 	}
 }

--- a/lint/rule_panel_promql_test.go
+++ b/lint/rule_panel_promql_test.go
@@ -2,25 +2,10 @@ package lint
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestPanelPromQLRule(t *testing.T) {
 	linter := NewPanelPromQLRule()
-	dashboard := Dashboard{
-		Title: "dashboard",
-		Templating: struct {
-			List []Template `json:"list"`
-		}{
-			List: []Template{
-				{
-					Type:  "datasource",
-					Query: "prometheus",
-				},
-			},
-		},
-	}
 
 	for _, tc := range []struct {
 		result Result
@@ -134,6 +119,23 @@ func TestPanelPromQLRule(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
+		dashboard := Dashboard{
+			Title: "dashboard",
+			Templating: struct {
+				List []Template `json:"list"`
+			}{
+				List: []Template{
+					{
+						Type:  "datasource",
+						Query: "prometheus",
+					},
+				},
+			},
+			Panels: []Panel{
+				tc.panel,
+			},
+		}
+
+		testRule(t, linter, dashboard, tc.result)
 	}
 }

--- a/lint/rule_panel_rate_interval_test.go
+++ b/lint/rule_panel_rate_interval_test.go
@@ -2,25 +2,10 @@ package lint
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestPanelRateIntervalRule(t *testing.T) {
 	linter := NewPanelRateIntervalRule()
-	dashboard := Dashboard{
-		Title: "dashboard",
-		Templating: struct {
-			List []Template `json:"list"`
-		}{
-			List: []Template{
-				{
-					Type:  "datasource",
-					Query: "prometheus",
-				},
-			},
-		},
-	}
 
 	for _, tc := range []struct {
 		result Result
@@ -102,6 +87,21 @@ func TestPanelRateIntervalRule(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintPanel(dashboard, tc.panel))
+		dashboard := Dashboard{
+			Title: "dashboard",
+			Templating: struct {
+				List []Template `json:"list"`
+			}{
+				List: []Template{
+					{
+						Type:  "datasource",
+						Query: "prometheus",
+					},
+				},
+			},
+			Panels: []Panel{tc.panel},
+		}
+
+		testRule(t, linter, dashboard, tc.result)
 	}
 }

--- a/lint/rule_template_datasource_test.go
+++ b/lint/rule_template_datasource_test.go
@@ -2,8 +2,6 @@ package lint
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestTemplateDatasource(t *testing.T) {
@@ -104,6 +102,6 @@ func TestTemplateDatasource(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintDashboard(tc.dashboard))
+		testRule(t, linter, tc.dashboard, tc.result)
 	}
 }

--- a/lint/rule_template_job_test.go
+++ b/lint/rule_template_job_test.go
@@ -2,8 +2,6 @@ package lint
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestJobDatasource(t *testing.T) {
@@ -155,6 +153,6 @@ func TestJobDatasource(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintDashboard(tc.dashboard))
+		testRule(t, linter, tc.dashboard, tc.result)
 	}
 }

--- a/lint/rule_template_label_promql_test.go
+++ b/lint/rule_template_label_promql_test.go
@@ -2,8 +2,6 @@ package lint
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestTemplateLabelPromQLRule(t *testing.T) {
@@ -169,6 +167,6 @@ func TestTemplateLabelPromQLRule(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.result, linter.LintDashboard(tc.dashboard))
+		testRule(t, linter, tc.dashboard, tc.result)
 	}
 }

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -11,6 +11,10 @@ type DashboardRuleFunc struct {
 	fn                func(Dashboard) Result
 }
 
+func NewDashboardRuleFunc(name, description string, fn func(Dashboard) Result) Rule {
+	return &DashboardRuleFunc{name, description, fn}
+}
+
 func (f DashboardRuleFunc) Name() string        { return f.name }
 func (f DashboardRuleFunc) Description() string { return f.description }
 func (f DashboardRuleFunc) Lint(d Dashboard, s *ResultSet) {
@@ -24,6 +28,10 @@ func (f DashboardRuleFunc) Lint(d Dashboard, s *ResultSet) {
 type PanelRuleFunc struct {
 	name, description string
 	fn                func(Dashboard, Panel) Result
+}
+
+func NewPanelRuleFunc(name, description string, fn func(Dashboard, Panel) Result) Rule {
+	return &PanelRuleFunc{name, description, fn}
 }
 
 func (f PanelRuleFunc) Name() string        { return f.name }
@@ -42,6 +50,10 @@ func (f PanelRuleFunc) Lint(d Dashboard, s *ResultSet) {
 type TargetRuleFunc struct {
 	name, description string
 	fn                func(Dashboard, Panel, Target) Result
+}
+
+func NewTargetRuleFunc(name, description string, fn func(Dashboard, Panel, Target) Result) Rule {
+	return &TargetRuleFunc{name, description, fn}
 }
 
 func (f TargetRuleFunc) Name() string        { return f.name }
@@ -88,11 +100,11 @@ func (s *RuleSet) Add(r Rule) {
 }
 
 func (s *RuleSet) Lint(dashboards []Dashboard) (*ResultSet, error) {
-	resSet := ResultSet{}
+	resSet := &ResultSet{}
 	for _, d := range dashboards {
 		for _, r := range s.rules {
-			r.Lint(d, &resSet)
+			r.Lint(d, resSet)
 		}
 	}
-	return &resSet, nil
+	return resSet, nil
 }

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -79,6 +79,18 @@ func (s *RuleSet) Rules() []Rule {
 	return result
 }
 
+func (s *RuleSet) Add(rule Rule) {
+	if dashboardRule, ok := rule.(DashboardRule); ok {
+		s.dashboardRules = append(s.dashboardRules, dashboardRule)
+	}
+	if panelRule, ok := rule.(PanelRule); ok {
+		s.panelRules = append(s.panelRules, panelRule)
+	}
+	if targetRule, ok := rule.(TargetRule); ok {
+		s.targetRules = append(s.targetRules, targetRule)
+	}
+}
+
 func (s *RuleSet) Lint(dashboards []Dashboard) (*ResultSet, error) {
 	resSet := &ResultSet{}
 

--- a/lint/rules_test.go
+++ b/lint/rules_test.go
@@ -1,0 +1,121 @@
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/grafana/dashboard-linter/lint"
+	"github.com/stretchr/testify/assert"
+)
+
+const dashboard = `{
+	"panels": [
+		{
+			"type": "timeseries",
+			"title": "Timeseries",
+			"targets": [
+				{
+					"expr": "up{job=\"$job\"}"
+				}
+			]
+		}
+	],
+	"templating": {
+		"list": [
+			{
+				"current": {
+					"text": "default",
+					"value": "default"
+				},
+				"hide": 0,
+				"label": "Data Source",
+				"name": "datasource",
+				"options": [ ],
+				"query": "prometheus",
+				"refresh": 1,
+				"regex": "",
+				"type": "datasource"
+			},
+			{
+				"name": "job",
+				"label": "job",
+				"datasource": "$datasource",
+				"type": "query",
+				"query": "query_result(up{})",
+				"multi": true,
+				"allValue": ".+"
+			}
+		]
+	},
+	"title": "Sample dashboard"
+}`
+
+type Rule struct {
+	RuleName string
+}
+
+func (rule *Rule) Name() string {
+	return rule.RuleName
+}
+
+func (rule *Rule) Description() string {
+	return "Test rule"
+}
+
+type CustomDashboardRule struct {
+	Rule
+}
+
+func (rule *CustomDashboardRule) LintDashboard(dashboard lint.Dashboard) lint.Result {
+	return lint.Result{Severity: lint.Error, Message: "Error found"}
+}
+
+type CustomPanelRule struct {
+	Rule
+}
+
+func (rule *CustomPanelRule) LintPanel(dashboard lint.Dashboard, panel lint.Panel) lint.Result {
+	return lint.Result{Severity: lint.Error, Message: "Error found"}
+}
+
+type CustomTargetRule struct {
+	Rule
+}
+
+func (rule *CustomTargetRule) LintTarget(dashboard lint.Dashboard, panel lint.Panel, target lint.Target) lint.Result {
+	return lint.Result{Severity: lint.Error, Message: "Error found"}
+}
+
+func TestCustomRules(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		rule lint.Rule
+	}{
+		{
+			desc: "Should allow addition of dashboard rule",
+			rule: &CustomDashboardRule{Rule: Rule{RuleName: "test-dashboard-rule"}},
+		},
+		{
+			desc: "Should allow addition of panel rule",
+			rule: &CustomPanelRule{Rule: Rule{RuleName: "test-panel-rule"}},
+		},
+		{
+			desc: "Should allow addition of target rule",
+			rule: &CustomTargetRule{Rule: Rule{RuleName: "test-target-rule"}},
+		},
+	} {
+		rules := lint.NewRuleSet()
+		// Add custom rule
+		rules.Add(tc.rule)
+		// Lint
+		dashboard, err := lint.NewDashboard([]byte(dashboard))
+		assert.NoError(t, err, tc.desc)
+		result, err := rules.Lint([]lint.Dashboard{dashboard})
+		assert.NoError(t, err, tc.desc)
+		// Validate the error was added
+		results := result.ByRule()
+		assert.Len(t, results[tc.rule.Name()], 1)
+		for _, result := range results[tc.rule.Name()] {
+			assert.Equal(t, result.Result, lint.Result{Severity: lint.Error, Message: "Error found"})
+		}
+	}
+}

--- a/lint/variables.go
+++ b/lint/variables.go
@@ -119,7 +119,7 @@ func variableSampleValue(s string) (string, error) {
 		kind = parts[1]
 		format = parts[2]
 	default:
-		return "", fmt.Errorf("Unknown variable format: %s", s)
+		return "", fmt.Errorf("unknown variable format: %s", s)
 	}
 	// If it is part of the globals, return a string representation of a sample value
 	if value, ok := globalVariables[name]; ok {

--- a/lint/variables_test.go
+++ b/lint/variables_test.go
@@ -140,7 +140,7 @@ func TestVariableExpansion(t *testing.T) {
 		{
 			desc: "Should return an error for unknown syntax",
 			expr: "max by(${a:b:c:d}) (rate(cpu{}[$__rate_interval]))",
-			err:  fmt.Errorf("Unknown variable format: a:b:c:d"),
+			err:  fmt.Errorf("unknown variable format: a:b:c:d"),
 		},
 	} {
 		s, err := expandVariables(tc.expr)


### PR DESCRIPTION
Hello,
I my company, we have a rule that the first panel of a dashboard should be named "Dashboard Info" and should contain some panels with PoC, ...
I was hoping, thanks to this PR to replace my current `jq` based solution with a Custom Rule integrated to the linter.
My intent is to gather feedback on the idea. Before merging I would like to add some test cases, to at least validate the case when a rule implements several interfaces (dashboard, panel, target linter).
Thanks again in advance for your inputs
Gabriel