### PR TITLE
List also panels nested inside a "row" type of panel

### DIFF
--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -3,8 +3,10 @@ package lint
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +42,14 @@ func TestParseDatasource(t *testing.T) {
 		require.Equal(t, tc.err, err)
 		require.Equal(t, tc.expected, actual)
 	}
+}
+
+func TestParseDashboard(t *testing.T) {
+	sampleDashboard, err := ioutil.ReadFile("testdata/dashboard.json")
+	assert.NoError(t, err)
+	t.Run("Row panels", func(t *testing.T) {
+		dashboard, err := NewDashboard(sampleDashboard)
+		assert.NoError(t, err)
+		assert.Len(t, dashboard.GetPanels(), 4)
+	})
 }

--- a/lint/testdata/dashboard.json
+++ b/lint/testdata/dashboard.json
@@ -1,0 +1,71 @@
+{
+  "rows": [
+    {
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "Timeseries",
+          "targets": [
+            {
+              "expr": "up{job=\"$job\"}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Timeseries",
+      "targets": [
+        {
+          "expr": "up{job=\"$job\"}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Dashboard row",
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "Timeseries",
+          "targets": [
+            {
+              "expr": "up{job=\"$job\"}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data Source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "name": "job",
+        "label": "job",
+        "datasource": "$datasource",
+        "type": "query",
+        "query": "query_result(up{})",
+        "multi": true,
+        "allValue": ".+"
+      }
+    ]
+  },
+  "title": "Sample dashboard"
+}


### PR DESCRIPTION
Hello,

Found this one while testing internally. My problem is that I have plenty of dashboards that have collapsed rows, meaning the panels are nested this way:
```
{
    "panels": [
        {
            "type": "row",
            "panels": [...]
        }
    ]
}
```
This PR ensures those panels are parsed and linted too.