### PR TITLE
Allow template variables to use ${datasource} instead of $datasource

### DIFF
--- a/lint/rule_template_job.go
+++ b/lint/rule_template_job.go
@@ -42,7 +42,7 @@ func checkTemplate(d Dashboard, name string) *Result {
 		}
 	}
 
-	if t.Datasource != "$datasource" {
+	if t.Datasource != "$datasource" && t.Datasource != "${datasource}" {
 		return &Result{
 			Severity: Error,
 			Message:  fmt.Sprintf("Dashboard '%s' %s template should use datasource '$datasource'", d.Title, name),
@@ -77,10 +77,7 @@ func checkTemplate(d Dashboard, name string) *Result {
 		}
 	}
 
-	return &Result{
-		Severity: Success,
-		Message:  "OK",
-	}
+	return nil
 }
 
 func getTemplate(d Dashboard, name string) *Template {

--- a/lint/rule_template_job_test.go
+++ b/lint/rule_template_job_test.go
@@ -116,6 +116,34 @@ func TestJobDatasource(t *testing.T) {
 				},
 			},
 		},
+		// Missing instance templates.
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test' is missing the instance template",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Query: "prometheus",
+						},
+						{
+							Name:       "job",
+							Datasource: "$datasource",
+							Type:       "query",
+							Label:      "job",
+							Multi:      true,
+							AllValue:   ".+",
+						},
+					},
+				},
+			},
+		},
 		// What success looks like.
 		{
 			result: Result{
@@ -142,7 +170,7 @@ func TestJobDatasource(t *testing.T) {
 						},
 						{
 							Name:       "instance",
-							Datasource: "$datasource",
+							Datasource: "${datasource}",
 							Type:       "query",
 							Label:      "instance",
 							Multi:      true,


### PR DESCRIPTION
Also fixes a bug where the instance template was never checked.

Part (1) of https://github.com/monitoring-mixins/mixtool/issues/57

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

