### PR TITLE
Check $__rate_interval only for rate functions

### DIFF
--- a/lint/rule_panel_rate_interval.go
+++ b/lint/rule_panel_rate_interval.go
@@ -2,14 +2,28 @@ package lint
 
 import (
 	"fmt"
-	"regexp"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
-var rangeVectorRegexp = regexp.MustCompile(`\[([^:)]+)\]`)
+type inspector func(parser.Node, []parser.Node) error
+
+func (f inspector) Visit(node parser.Node, path []parser.Node) (parser.Visitor, error) {
+	if err := f(node, path); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
 
 // NewPanelRateIntervalRule builds a lint rule for panels with Prometheus queries which checks
 // all range vector selectors use $__rate_interval.
 func NewPanelRateIntervalRule() *PanelRuleFunc {
+	rateIntervalMagicDuration, err := time.ParseDuration(globalVariables["__rate_interval"].(string))
+	if err != nil {
+		// Will not happen
+		panic(err)
+	}
 	return &PanelRuleFunc{
 		name:        "panel-rate-interval-rule",
 		description: "Checks that each panel uses $__rate_interval.",
@@ -31,13 +45,43 @@ func NewPanelRateIntervalRule() *PanelRuleFunc {
 			}
 
 			for _, target := range p.Targets {
-				// Hack in replace [$__rate_interval] with [5m] so queries parse correctly.
-				for _, rate := range rangeVectorRegexp.FindAllString(target.Expr, -1) {
-					if rate != "[$__rate_interval]" {
-						return Result{
-							Severity: Error,
-							Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid PromQL query '%s': should use $__rate_interval", d.Title, p.Title, target.Expr),
-						}
+				expr, err := parsePromQL(target.Expr, d.Templating.List)
+				if err != nil {
+					continue
+				}
+				err = parser.Walk(inspector(func(node parser.Node, parents []parser.Node) error {
+					selector, ok := node.(*parser.MatrixSelector)
+					if !ok {
+						// We are not inspecting something like foo{...}[...]
+						return nil
+					}
+
+					if selector.Range == rateIntervalMagicDuration {
+						// Range vector selector is $__rate_interval
+						return nil
+					}
+
+					if len(parents) == 0 {
+						// Bit weird to have a naked foo[$__rate_interval], but allow it.
+						return nil
+					}
+					// Now check if the parent is a rate function
+					call, ok := parents[len(parents)-1].(*parser.Call)
+					if !ok {
+						return fmt.Errorf("Dashboard '%s', panel '%s' invalid PromQL query '%s': $__rate_interval used in non-rate function", d.Title, p.Title, target.Expr)
+					}
+
+					if call.Func.Name != "rate" && call.Func.Name != "irate" {
+						// the parent is not an (i)rate function call, allow it
+						return nil
+					}
+
+					return fmt.Errorf("Dashboard '%s', panel '%s' invalid PromQL query '%s': should use $__rate_interval", d.Title, p.Title, target.Expr)
+				}), expr, nil)
+				if err != nil {
+					return Result{
+						Severity: Error,
+						Message:  err.Error(),
 					}
 				}
 			}

--- a/lint/rule_panel_rate_interval_test.go
+++ b/lint/rule_panel_rate_interval_test.go
@@ -86,6 +86,38 @@ func TestPanelRateIntervalRule(t *testing.T) {
 				},
 			},
 		},
+		// Non-rate functions should not make the linter fail
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(increase(foo{job=~"$job",instance=~"$instance"}[$__range]))`,
+					},
+				},
+			},
+		},
+		// irate should be checked too
+		{
+			result: Result{
+				Severity: Error,
+				Message:  `Dashboard 'dashboard', panel 'panel' invalid PromQL query 'sum(irate(foo{job=~"$job",instance=~"$instance"}[$__interval]))': should use $__rate_interval`,
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `sum(irate(foo{job=~"$job",instance=~"$instance"}[$__interval]))`,
+					},
+				},
+			},
+		},
 	} {
 		dashboard := Dashboard{
 			Title: "dashboard",


### PR DESCRIPTION
Hello,
This should cover a case I have internally, with a query like `sum(increase(foo{...}[$__range]))` interval, which I believe should not be rejected by the linter.
Let me know if you have concerns.
Gabriel