### PR TITLE
Reuse a common ResultSuccess for all success cases to simplify code

### DIFF
--- a/lint/results.go
+++ b/lint/results.go
@@ -5,6 +5,11 @@ import (
 	"sort"
 )
 
+var ResultSuccess = Result{
+	Severity: Success,
+	Message:  "OK",
+}
+
 type Result struct {
 	Severity Severity
 	Message  string

--- a/lint/rule_panel_datasource.go
+++ b/lint/rule_panel_datasource.go
@@ -20,10 +20,7 @@ func NewPanelDatasourceRule() *PanelRuleFunc {
 				}
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }

--- a/lint/rule_panel_job_instance.go
+++ b/lint/rule_panel_job_instance.go
@@ -16,27 +16,18 @@ func NewPanelJobInstanceRule() *PanelRuleFunc {
 		fn: func(d Dashboard, p Panel) Result {
 			if t := getTemplateDatasource(d); t == nil || t.Query != "prometheus" {
 				// Missing template datasources is a separate rule.
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			if !panelHasQueries(p) {
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			for _, target := range p.Targets {
 				node, err := parsePromQL(target.Expr, d.Templating.List)
 				if err != nil {
 					// Invalid PromQL is another rule.
-					return Result{
-						Severity: Success,
-						Message:  "OK",
-					}
+					return ResultSuccess
 				}
 
 				for _, selector := range parser.ExtractSelectors(node) {
@@ -56,10 +47,7 @@ func NewPanelJobInstanceRule() *PanelRuleFunc {
 				}
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }

--- a/lint/rule_panel_promql.go
+++ b/lint/rule_panel_promql.go
@@ -40,17 +40,11 @@ func NewPanelPromQLRule() *PanelRuleFunc {
 		fn: func(d Dashboard, p Panel) Result {
 			if t := getTemplateDatasource(d); t == nil || t.Query != "prometheus" {
 				// Missing template datasources is a separate rule.
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			if !panelHasQueries(p) {
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			for _, target := range p.Targets {
@@ -62,10 +56,7 @@ func NewPanelPromQLRule() *PanelRuleFunc {
 				}
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }

--- a/lint/rule_panel_rate_interval.go
+++ b/lint/rule_panel_rate_interval.go
@@ -16,18 +16,12 @@ func NewPanelRateIntervalRule() *PanelRuleFunc {
 		fn: func(d Dashboard, p Panel) Result {
 			if t := getTemplateDatasource(d); t == nil || t.Query != "prometheus" {
 				// Missing template datasources is a separate rule.
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			if !panelHasQueries(p) {
 				// Don't lint certain types of panels.
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			for _, target := range p.Targets {
@@ -42,10 +36,7 @@ func NewPanelRateIntervalRule() *PanelRuleFunc {
 				}
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }

--- a/lint/rule_template_datasource.go
+++ b/lint/rule_template_datasource.go
@@ -38,10 +38,7 @@ func NewTemplateDatasourceRule() *DashboardRuleFunc {
 				}
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }

--- a/lint/rule_template_job.go
+++ b/lint/rule_template_job.go
@@ -11,10 +11,7 @@ func NewTemplateJobRule() *DashboardRuleFunc {
 		fn: func(d Dashboard) Result {
 			template := getTemplateDatasource(d)
 			if template == nil || template.Query != "prometheus" {
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 
 			if r := checkTemplate(d, "job"); r != nil {
@@ -25,10 +22,7 @@ func NewTemplateJobRule() *DashboardRuleFunc {
 				return *r
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }

--- a/lint/rule_template_label_promql.go
+++ b/lint/rule_template_label_promql.go
@@ -46,10 +46,7 @@ func NewTemplateLabelPromQLRule() *DashboardRuleFunc {
 		fn: func(d Dashboard) Result {
 			template := getTemplateDatasource(d)
 			if template == nil || template.Query != "prometheus" {
-				return Result{
-					Severity: Success,
-					Message:  "OK",
-				}
+				return ResultSuccess
 			}
 			for _, template := range d.Templating.List {
 				if template.Type != "query" {
@@ -63,10 +60,7 @@ func NewTemplateLabelPromQLRule() *DashboardRuleFunc {
 				}
 			}
 
-			return Result{
-				Severity: Success,
-				Message:  "OK",
-			}
+			return ResultSuccess
 		},
 	}
 }


### PR DESCRIPTION
Simplify a bit the source code with shared SuccessResult