### PR TITLE
Actually unmarshal dashboard template options and current value. Resolves #35

### DIFF
--- a/lint/configuration.go
+++ b/lint/configuration.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // ConfigurationFile contains a map for rule exclusions, and warnings, where the key is the

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -29,6 +29,7 @@ type Template struct {
 	AllValue   string           `json:"allValue"`
 	Current    TemplateValue    `json:"current"`
 	Options    []TemplateOption `json:"options"`
+	// If you add properties here don't forget to add them to the raw struct, and assign them from raw to actual in UnmarshalJSON below!
 }
 
 type TemplateValue struct {
@@ -43,13 +44,15 @@ type TemplateOption struct {
 
 func (t *Template) UnmarshalJSON(buf []byte) error {
 	var raw struct {
-		Name       string      `json:"name"`
-		Label      string      `json:"label"`
-		Type       string      `json:"type"`
-		Query      interface{} `json:"query"`
-		Datasource Datasource  `json:"datasource"`
-		Multi      bool        `json:"multi"`
-		AllValue   string      `json:"allValue"`
+		Name       string           `json:"name"`
+		Label      string           `json:"label"`
+		Type       string           `json:"type"`
+		Query      interface{}      `json:"query"`
+		Datasource Datasource       `json:"datasource"`
+		Multi      bool             `json:"multi"`
+		AllValue   string           `json:"allValue"`
+		Current    TemplateValue    `json:"current"`
+		Options    []TemplateOption `json:"options"`
 	}
 
 	if err := json.Unmarshal(buf, &raw); err != nil {
@@ -62,6 +65,8 @@ func (t *Template) UnmarshalJSON(buf []byte) error {
 	t.Datasource = raw.Datasource
 	t.Multi = raw.Multi
 	t.AllValue = raw.AllValue
+	t.Current = raw.Current
+	t.Options = raw.Options
 
 	switch v := raw.Query.(type) {
 	case string:


### PR DESCRIPTION
Turns out the work that is described in #35 was already complete in the [variables.go](https://github.com/grafana/dashboard-linter/blob/main/lint/variables.go) file, quite elegantly I might add.

The error described in that issue was the result of some of the template properties not getting unmarshalled, which this PR resolves.

This also cherry-picks the lint fix from #37 