### PR TITLE
Add support for multiple datasources

### DIFF
--- a/lint/configuration.go
+++ b/lint/configuration.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // ConfigurationFile contains a map for rule exclusions, and warnings, where the key is the

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -15,6 +15,7 @@ const (
 	Quiet
 
 	Prometheus = "prometheus"
+	Loki       = "loki"
 )
 
 // Target is a deliberately incomplete representation of the Dashboard -> Template type in grafana.

--- a/lint/rule_panel_datasource.go
+++ b/lint/rule_panel_datasource.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"fmt"
+	"strings"
 )
 
 func NewPanelDatasourceRule() *PanelRuleFunc {
@@ -11,10 +12,11 @@ func NewPanelDatasourceRule() *PanelRuleFunc {
 		fn: func(d Dashboard, p Panel) Result {
 			switch p.Type {
 			case "singlestat", "graph", "table", "timeseries":
-				if p.Datasource != "$datasource" && p.Datasource != "${datasource}" {
+
+				if expectedDatasources := checkTemplatedDatasourceUsed(d, p.Datasource); len(expectedDatasources) > 0 {
 					return Result{
 						Severity: Error,
-						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' does not use templates datasource, uses '%s'", d.Title, p.Title, p.Datasource),
+						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' does not use %s for datasource, uses '%s'", d.Title, p.Title, strings.Join(expectedDatasources, " or "), p.Datasource),
 					}
 				}
 			}

--- a/lint/rule_template_datasource.go
+++ b/lint/rule_template_datasource.go
@@ -2,47 +2,95 @@ package lint
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 )
+
+// This rule checks that the dashboard has single templated datasource
+func (d *Dashboard) checkPrometheusOrLokiDS(template *Template) Result {
+
+	if template.Name != "datasource" {
+		return Result{
+			Severity: Error,
+			Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable named '%s', should be named 'datasource'", d.Title, template.Name),
+		}
+	}
+
+	if template.Label != "Data Source" {
+		return Result{
+			Severity: Error,
+			Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable labeled '%s', should be labeled 'Data Source'", d.Title, template.Label),
+		}
+	}
+
+	if template.Query != Prometheus && template.Query != Loki {
+		return Result{
+			Severity: Error,
+			Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable query is '%s', should be 'prometheus' or 'loki'", d.Title, template.Query),
+		}
+	}
+	return ResultSuccess
+}
+
+func (d *Dashboard) checkPrometheusAndLokiDS(datasources []Template) Result {
+
+	// move loki to 0 index
+	sort.SliceStable(datasources, func(i, j int) bool {
+		return datasources[i].Query < datasources[j].Query
+	})
+
+	if !(datasources[0].Query == Loki && datasources[1].Query == Prometheus) {
+		return Result{
+			Severity: Error,
+			Message:  fmt.Sprintf("Dashboard '%s' with 2 templated datasources should have 'prometheus' and 'loki' types", d.Title),
+		}
+	}
+
+	for _, template := range datasources {
+		prefix := template.Query
+
+		expected_name := prefix + "_datasource"
+		if template.Name != expected_name {
+			return Result{
+				Severity: Error,
+				Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable named '%s', should be named '%s'", d.Title, template.Name, expected_name),
+			}
+		}
+
+		expected_label := strings.Title(prefix) + " Data Source"
+		if template.Label != expected_label {
+			return Result{
+				Severity: Error,
+				Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable labeled '%s', should be labeled '%s'", d.Title, template.Label, expected_label),
+			}
+		}
+	}
+
+	return ResultSuccess
+}
 
 func NewTemplateDatasourceRule() *DashboardRuleFunc {
 	return &DashboardRuleFunc{
 		name:        "template-datasource-rule",
 		description: "Checks that the dashboard has a templated datasource.",
 		fn: func(d Dashboard) Result {
-			template := getTemplateDatasource(d)
-			if template == nil {
+
+			datasources := getTemplateDatasources(d)
+			if len(datasources) == 1 {
+				return d.checkPrometheusOrLokiDS(&datasources[0])
+			} else if len(datasources) == 2 {
+				return d.checkPrometheusAndLokiDS(datasources)
+			} else {
 				return Result{
 					Severity: Error,
-					Message:  fmt.Sprintf("Dashboard '%s' does not have a templated datasource", d.Title),
+					Message:  fmt.Sprintf("Dashboard '%s' has %d templated datasources, should be 1 or 2", d.Title, len(datasources)),
 				}
 			}
-
-			if template.Name != "datasource" {
-				return Result{
-					Severity: Error,
-					Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable named '%s', should be names 'datasource'", d.Title, template.Name),
-				}
-			}
-
-			if template.Label != "Data Source" {
-				return Result{
-					Severity: Error,
-					Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable labeled '%s', should be labeled 'Data Source'", d.Title, template.Label),
-				}
-			}
-
-			if template.Query != Prometheus && template.Query != "loki" {
-				return Result{
-					Severity: Error,
-					Message:  fmt.Sprintf("Dashboard '%s' templated datasource variable query is '%s', should be 'prometheus' or 'loki'", d.Title, template.Query),
-				}
-			}
-
-			return ResultSuccess
 		},
 	}
 }
 
+//Returns only first datasource found
 func getTemplateDatasource(d Dashboard) *Template {
 	for _, template := range d.Templating.List {
 		if template.Type != "datasource" {
@@ -51,4 +99,34 @@ func getTemplateDatasource(d Dashboard) *Template {
 		return &template
 	}
 	return nil
+}
+
+func getTemplateDatasources(d Dashboard) []Template {
+
+	templateDatasources := []Template{}
+	for _, template := range d.Templating.List {
+		if template.Type != "datasource" {
+			continue
+		}
+		templateDatasources = append(templateDatasources, template)
+	}
+	return templateDatasources
+}
+
+// Returns datasource names that should be used instead of provided datasource
+func checkTemplatedDatasourceUsed(d Dashboard, datasource Datasource) []string {
+
+	datasource_count := len(getTemplateDatasources(d))
+	if datasource_count == 1 {
+		if datasource != "$datasource" && datasource != "${datasource}" {
+			return []string{"$datasource"}
+		}
+	} else if datasource_count == 2 {
+
+		if datasource != "$prometheus_datasource" && datasource != "${prometheus_datasource}" &&
+			datasource != "$loki_datasource" && datasource != "${loki_datasource}" {
+			return []string{"$prometheus_datasource", "$loki_datasource"}
+		}
+	}
+	return []string{}
 }

--- a/lint/rule_template_datasource_test.go
+++ b/lint/rule_template_datasource_test.go
@@ -14,7 +14,7 @@ func TestTemplateDatasource(t *testing.T) {
 		{
 			result: Result{
 				Severity: Error,
-				Message:  "Dashboard 'test' does not have a templated datasource",
+				Message:  "Dashboard 'test' has 0 templated datasources, should be 1 or 2",
 			},
 			dashboard: Dashboard{
 				Title: "test",
@@ -23,7 +23,7 @@ func TestTemplateDatasource(t *testing.T) {
 		{
 			result: Result{
 				Severity: Error,
-				Message:  "Dashboard 'test' templated datasource variable named 'foo', should be names 'datasource'",
+				Message:  "Dashboard 'test' templated datasource variable named 'foo', should be named 'datasource'",
 			},
 			dashboard: Dashboard{
 				Title: "test",
@@ -96,6 +96,143 @@ func TestTemplateDatasource(t *testing.T) {
 							Name:  "datasource",
 							Label: "Data Source",
 							Query: "prometheus",
+						},
+					},
+				},
+			},
+		},
+		// multiple datasources cases below
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Name:  "prometheus_datasource",
+							Label: "Prometheus Data Source",
+							Query: "prometheus",
+						},
+						{
+							Type:  "datasource",
+							Name:  "loki_datasource",
+							Label: "Loki Data Source",
+							Query: "loki",
+						},
+					},
+				},
+			},
+		},
+		// swap
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Name:  "loki_datasource",
+							Label: "Loki Data Source",
+							Query: "loki",
+						},
+						{
+							Type:  "datasource",
+							Name:  "prometheus_datasource",
+							Label: "Prometheus Data Source",
+							Query: "prometheus",
+						},
+					},
+				},
+			},
+		},
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test' with 2 templated datasources should have 'prometheus' and 'loki' types",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Name:  "prometheus_datasource",
+							Label: "Prometheus Data Source",
+							Query: "prometheus",
+						},
+						{
+							Type:  "datasource",
+							Name:  "datasource",
+							Label: "Data Source",
+							Query: "influx",
+						},
+					},
+				},
+			},
+		},
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test' templated datasource variable named 'logs_datasource', should be named 'loki_datasource'",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Name:  "prometheus_datasource",
+							Label: "Prometheus Data Source",
+							Query: "prometheus",
+						},
+						{
+							Type:  "datasource",
+							Name:  "logs_datasource",
+							Label: "Loki Data Source",
+							Query: "loki",
+						},
+					},
+				},
+			},
+		},
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test' templated datasource variable labeled 'Logs Data Source', should be labeled 'Loki Data Source'",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Name:  "prometheus_datasource",
+							Label: "Prometheus Data Source",
+							Query: "prometheus",
+						},
+						{
+							Type:  "datasource",
+							Name:  "loki_datasource",
+							Label: "Logs Data Source",
+							Query: "loki",
 						},
 					},
 				},

--- a/lint/rule_template_job.go
+++ b/lint/rule_template_job.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"fmt"
+	"strings"
 )
 
 func NewTemplateJobRule() *DashboardRuleFunc {
@@ -36,10 +37,10 @@ func checkTemplate(d Dashboard, name string) *Result {
 		}
 	}
 
-	if t.Datasource != "$datasource" && t.Datasource != "${datasource}" {
+	if expectedDatasources := checkTemplatedDatasourceUsed(d, t.Datasource); len(expectedDatasources) > 0 {
 		return &Result{
 			Severity: Error,
-			Message:  fmt.Sprintf("Dashboard '%s' %s template should use datasource '$datasource', is currently '%s'", d.Title, name, t.Datasource),
+			Message:  fmt.Sprintf("Dashboard '%s' %s template should use datasource %s, is currently '%s'", d.Title, name, strings.Join(expectedDatasources, " or "), t.Datasource),
 		}
 	}
 

--- a/lint/rule_template_job_test.go
+++ b/lint/rule_template_job_test.go
@@ -11,7 +11,7 @@ func TestJobDatasource(t *testing.T) {
 		result    Result
 		dashboard Dashboard
 	}{
-		// Non-promtheus dashboards shouldn't fail.
+		// Non-prometheus dashboards shouldn't fail.
 		{
 			result: Result{
 				Severity: Success,
@@ -45,7 +45,7 @@ func TestJobDatasource(t *testing.T) {
 		{
 			result: Result{
 				Severity: Error,
-				Message:  "Dashboard 'test' job template should use datasource '$datasource', is currently 'foo'",
+				Message:  "Dashboard 'test' job template should use datasource $datasource, is currently 'foo'",
 			},
 			dashboard: Dashboard{
 				Title: "test",
@@ -56,6 +56,34 @@ func TestJobDatasource(t *testing.T) {
 						{
 							Type:  "datasource",
 							Query: "prometheus",
+						},
+						{
+							Name:       "job",
+							Datasource: "foo",
+						},
+					},
+				},
+			},
+		},
+		// Wrong datasource (multiple datasources).
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test' job template should use datasource $prometheus_datasource or $loki_datasource, is currently 'foo'",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Query: "prometheus",
+						},
+						{
+							Type:  "datasource",
+							Query: "loki",
 						},
 						{
 							Name:       "job",


### PR DESCRIPTION
Add support for multiple datasources.
prometheus and loki.

If single templated datasource found:

- Should be named $datasource with label "Data Source"

If two templated datasources found:
- Prometheus should be named $prometheus_datasource with label "Prometheus Data Source"
- Loki should be named $loki_datasource with label "Loki Data Source"
