### PR TITLE
Ignored query field check for adhoc variables

### DIFF
--- a/lint/configuration.go
+++ b/lint/configuration.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // ConfigurationFile contains a map for rule exclusions, and warnings, where the key is the

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -63,13 +63,16 @@ func (t *Template) UnmarshalJSON(buf []byte) error {
 	t.Multi = raw.Multi
 	t.AllValue = raw.AllValue
 
-	switch v := raw.Query.(type) {
-	case string:
-		t.Query = v
-	case map[string]interface{}:
-		t.Query = v["query"].(string)
-	default:
-		return fmt.Errorf("invalid type for field 'query': %v", v)
+	// the 'adhoc' variable type does not have a field `Query`, so we can't perform these checks for the `adhoc` type
+	if t.Type != "adhoc" {
+		switch v := raw.Query.(type) {
+		case string:
+			t.Query = v
+		case map[string]interface{}:
+			t.Query = v["query"].(string)
+		default:
+			return fmt.Errorf("invalid type for field 'query': %v", v)
+		}
 	}
 
 	return nil

--- a/lint/testdata/dashboard.json
+++ b/lint/testdata/dashboard.json
@@ -64,6 +64,13 @@
         "query": "query_result(up{})",
         "multi": true,
         "allValue": ".+"
+      },
+      {
+        "filters": [],
+        "hide": 0,
+        "name": "query0",
+        "skipUrlSync": false,
+        "type": "adhoc"
       }
     ]
   },


### PR DESCRIPTION
As stated in <https://github.com/grafana/dashboard-linter/issues/41>,
the linter will throw an error when the grafana dashboard has a variable
of type "adhoc".

This commit will ignore the query type check for "adhoc" variables and
will fix the issue mentioned above.

Fixes #41