### PR TITLE
Allow dashboard template vars with multiple options. Resolves #43

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -90,10 +90,13 @@ func (t *TemplateValue) UnmarshalJSON(buf []byte) error {
 		return err
 	}
 
-	if txt, ok := raw["text"]; !ok {
+	var txt, val interface{}
+
+	txt, ok := raw["text"]
+	if !ok {
 		return errors.New("'text' property required")
 	}
-	
+
 	switch tt := txt.(type) {
 	case string:
 		t.Text = txt.(string)
@@ -103,7 +106,8 @@ func (t *TemplateValue) UnmarshalJSON(buf []byte) error {
 		return fmt.Errorf("invalid type for field 'text': %v", tt)
 	}
 
-	if val, ok := raw["value"]; !ok {
+	val, ok = raw["value"]
+	if !ok {
 		return errors.New("'value' property required")
 	}
 

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -77,6 +78,41 @@ func (t *Template) UnmarshalJSON(buf []byte) error {
 			t.Query = v["query"].(string)
 		default:
 			return fmt.Errorf("invalid type for field 'query': %v", v)
+		}
+	}
+
+	return nil
+}
+
+func (t *TemplateValue) UnmarshalJSON(buf []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(buf, &raw); err != nil {
+		return err
+	}
+
+	if txt, ok := raw["text"]; !ok {
+		return errors.New("'text' property required")
+	} else {
+		switch tt := txt.(type) {
+		case string:
+			t.Text = txt.(string)
+		case []interface{}:
+			t.Text = txt.([]interface{})[0].(string)
+		default:
+			return fmt.Errorf("invalid type for field 'text': %v", tt)
+		}
+	}
+
+	if val, ok := raw["value"]; !ok {
+		return errors.New("'value' property required")
+	} else {
+		switch vt := val.(type) {
+		case string:
+			t.Value = val.(string)
+		case []interface{}:
+			t.Value = val.([]interface{})[0].(string)
+		default:
+			return fmt.Errorf("invalid type for field 'value': %v", vt)
 		}
 	}
 

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -105,15 +105,15 @@ func (t *TemplateValue) UnmarshalJSON(buf []byte) error {
 
 	if val, ok := raw["value"]; !ok {
 		return errors.New("'value' property required")
-	} else {
-		switch vt := val.(type) {
-		case string:
-			t.Value = val.(string)
-		case []interface{}:
-			t.Value = val.([]interface{})[0].(string)
-		default:
-			return fmt.Errorf("invalid type for field 'value': %v", vt)
-		}
+	}
+
+	switch vt := val.(type) {
+	case string:
+		t.Value = val.(string)
+	case []interface{}:
+		t.Value = val.([]interface{})[0].(string)
+	default:
+		return fmt.Errorf("invalid type for field 'value': %v", vt)
 	}
 
 	return nil

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -92,15 +92,15 @@ func (t *TemplateValue) UnmarshalJSON(buf []byte) error {
 
 	if txt, ok := raw["text"]; !ok {
 		return errors.New("'text' property required")
-	} else {
-		switch tt := txt.(type) {
-		case string:
-			t.Text = txt.(string)
-		case []interface{}:
-			t.Text = txt.([]interface{})[0].(string)
-		default:
-			return fmt.Errorf("invalid type for field 'text': %v", tt)
-		}
+	}
+	
+	switch tt := txt.(type) {
+	case string:
+		t.Text = txt.(string)
+	case []interface{}:
+		t.Text = txt.([]interface{})[0].(string)
+	default:
+		return fmt.Errorf("invalid type for field 'text': %v", tt)
 	}
 
 	if val, ok := raw["value"]; !ok {


### PR DESCRIPTION
This PR does some unmarshal magic to allow either a string. or an array of strings for `text` and `value`.

The `TemplateValue` struct remains unchanged. If the value is an array, the first element is used for the value.