### PR TITLE
Match an exclusion or warning rule when the entry is a partial match

### DIFF
--- a/lint/configuration.go
+++ b/lint/configuration.go
@@ -40,11 +40,11 @@ func (cre *ConfigurationRuleEntries) AddEntry(e ConfigurationEntry) {
 
 func (ce *ConfigurationEntry) IsMatch(r ResultContext) bool {
 	ret := true
-	if r.Dashboard != nil && ce.Dashboard != r.Dashboard.Title {
+	if ce.Dashboard != "" && r.Dashboard != nil && ce.Dashboard != r.Dashboard.Title {
 		ret = false
 	}
 
-	if r.Panel != nil && ce.Panel != r.Panel.Title {
+	if ce.Panel != "" && r.Panel != nil && ce.Panel != r.Panel.Title {
 		ret = false
 	}
 

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -167,14 +167,33 @@ func TestConfiguration(t *testing.T) {
 		appendConfigExclude(t, "rule1", "", "", "", c)
 		appendConfigExclude(t, "rule1", "dash1", "", "", c)
 
-		r1 := newResultContext(t, "rule1", "dash1", "", "", Error)
-		r2 := newResultContext(t, "rule1", "dash2", "", "", Error)
+		r1 := newResultContext(t, "rule1", "dash1", "foo", "0", Error)
+		r2 := newResultContext(t, "rule1", "dash2", "bar", "0", Error)
 
 		rc1 := c.Apply(r1)
 		require.Equal(t, Exclude, rc1.Result.Severity)
 
 		rc2 := c.Apply(r2)
 		require.Equal(t, Error, rc2.Result.Severity)
+	})
+
+	t.Run("Excludes multiple entries for the same rule", func(t *testing.T) {
+		c := NewConfigurationFile()
+		appendConfigExclude(t, "rule1", "dash1", "", "", c)
+		appendConfigExclude(t, "rule1", "dash2", "", "", c)
+
+		r1 := newResultContext(t, "rule1", "dash1", "", "", Error)
+		r2 := newResultContext(t, "rule1", "dash2", "", "", Error)
+		r3 := newResultContext(t, "rule1", "dash3", "", "", Error)
+
+		rc1 := c.Apply(r1)
+		require.Equal(t, Exclude, rc1.Result.Severity)
+
+		rc2 := c.Apply(r2)
+		require.Equal(t, Exclude, rc2.Result.Severity)
+
+		rc3 := c.Apply(r3)
+		require.Equal(t, Error, rc3.Result.Severity)
 	})
 
 	t.Run("Excludes all when rule defined but entries empty", func(t *testing.T) {


### PR DESCRIPTION
While working on an existing mixin, several dashboards have a similar reason for exclusion (shown below), but the linter was not excluding them.

Turns out that because the lint error contained a panel name and target idx, the match was not "exact" and was being skipped.

This PR resolves that, and allows partial matches for specific entries on a rule.

```
exclusions:
  target-instance-rule:    
    reason: These dashboards are cluster wide dashboards. As such 'cluster' takes the place of 'instance'
    entries:
    - dashboard: Kubernetes / Persistent Volumes
    - dashboard: Kubernetes / Compute Resources /  Multi-Cluster
    - dashboard: Kubernetes / Compute Resources / Node (Pods)
```