### PR TITLE
lint.go: Handle variable template values

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -2,7 +2,6 @@ package lint
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -93,31 +92,27 @@ func (t *TemplateValue) UnmarshalJSON(buf []byte) error {
 	var txt, val interface{}
 
 	txt, ok := raw["text"]
-	if !ok {
-		return errors.New("'text' property required")
-	}
-
-	switch tt := txt.(type) {
-	case string:
-		t.Text = txt.(string)
-	case []interface{}:
-		t.Text = txt.([]interface{})[0].(string)
-	default:
-		return fmt.Errorf("invalid type for field 'text': %v", tt)
+	if ok {
+		switch tt := txt.(type) {
+		case string:
+			t.Text = txt.(string)
+		case []interface{}:
+			t.Text = txt.([]interface{})[0].(string)
+		default:
+			return fmt.Errorf("invalid type for field 'text': %v", tt)
+		}
 	}
 
 	val, ok = raw["value"]
-	if !ok {
-		return errors.New("'value' property required")
-	}
-
-	switch vt := val.(type) {
-	case string:
-		t.Value = val.(string)
-	case []interface{}:
-		t.Value = val.([]interface{})[0].(string)
-	default:
-		return fmt.Errorf("invalid type for field 'value': %v", vt)
+	if ok {
+		switch vt := val.(type) {
+		case string:
+			t.Value = val.(string)
+		case []interface{}:
+			t.Value = val.([]interface{})[0].(string)
+		default:
+			return fmt.Errorf("invalid type for field 'value': %v", vt)
+		}
 	}
 
 	return nil

--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -79,13 +79,12 @@ func TestParseTemplateValue(t *testing.T) {
 			err:      errors.New("invalid type for field 'value': 2"),
 		},
 		{
-			input: []byte(`{}`),
-			err:   errors.New("'text' property required"),
+			input:    []byte(`{}`),
+			expected: TemplateValue{Text:"", Value:""},
 		},
 		{
 			input:    []byte(`{"text": "text"}`),
-			expected: TemplateValue{Text: "text"},
-			err:      errors.New("'value' property required"),
+			expected: TemplateValue{Text:"text", Value:""},
 		},
 	} {
 		var actual TemplateValue


### PR DESCRIPTION
Since the merge of https://github.com/grafana/dashboard-linter/pull/45 the linter breaks on jsons like this:

```
          {
            "allValue": ".+",
            "current": { },
            "datasource": "$datasource",
            "hide": 0,
            "includeAll": true,
            "label": "job",
            "multi": true,
            "name": "job",
            "options": [ ],
            "query": "label_values(awx_system_info, job)",
            "refresh": 1,
            "regex": "",
            "sort": 1,
            "tagValuesQuery": "",
            "tags": [ ],
            "tagsQuery": "",
            "type": "query",
            "useTags": false
         },
```

It will return an error: `Error: failed to parse dashboard: 'text' property required` even though it is valid in grafana. The handling of `"current": { },` is the part that causes the error, this PR fixes this behaviour. 