### PR TITLE
Separate job and instance template rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This tool is a work in progress, and its very early days.  Right now its focused
 The linter implements the following rules:
 
 * `template-datasource-rule` - Checks that the dashboard has a templated datasource.
-* `template-job-rule` - Checks that the dashboard has a templated job and instance.
+* `template-job-rule` - Checks that the dashboard has a templated job.
+* `template-instance-rule` - Checks that the dashboard has a templated instance.
 * `template-label-promql-rule` - Checks that the dashboard templated labels have proper PromQL expressions.
 * `panel-datasource-rule` - Checks that each panel uses the templated datasource.
 * `target-promql-rule` - Checks that each target uses a valid PromQL query.
@@ -29,5 +30,5 @@ Where the rules above don't make sense, you can drop a `.lint` file in a same di
 ```yaml
 exclusions:
   template-job-rule:
-    reason: "Job & instance not needed, using recording rules."
+    reason: "Job not needed, using recording rules."
 ```

--- a/lint/rule_template_instance.go
+++ b/lint/rule_template_instance.go
@@ -1,0 +1,20 @@
+package lint
+
+func NewTemplateInstanceRule() *DashboardRuleFunc {
+	return &DashboardRuleFunc{
+		name:        "template-instance-rule",
+		description: "Checks that the dashboard has a templated instance.",
+		fn: func(d Dashboard) Result {
+			template := getTemplateDatasource(d)
+			if template == nil || template.Query != Prometheus {
+				return ResultSuccess
+			}
+
+			if r := checkTemplate(d, "instance"); r != nil {
+				return *r
+			}
+
+			return ResultSuccess
+		},
+	}
+}

--- a/lint/rule_template_instance_test.go
+++ b/lint/rule_template_instance_test.go
@@ -1,0 +1,89 @@
+package lint
+
+import "testing"
+
+func TestInstanceTemplate(t *testing.T) {
+	linter := NewTemplateInstanceRule()
+
+	for _, tc := range []struct {
+		result    Result
+		dashboard Dashboard
+	}{
+		// Non-promtheus dashboards shouldn't fail.
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+			},
+		},
+		// Missing instance templates.
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test' is missing the instance template",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Query: "prometheus",
+						},
+						{
+							Name:       "job",
+							Datasource: "$datasource",
+							Type:       "query",
+							Label:      "job",
+							Multi:      true,
+							AllValue:   ".+",
+						},
+					},
+				},
+			},
+		},
+		// What success looks like.
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			dashboard: Dashboard{
+				Title: "test",
+				Templating: struct {
+					List []Template `json:"list"`
+				}{
+					List: []Template{
+						{
+							Type:  "datasource",
+							Query: "prometheus",
+						},
+						{
+							Name:       "job",
+							Datasource: "$datasource",
+							Type:       "query",
+							Label:      "job",
+							Multi:      true,
+							AllValue:   ".+",
+						},
+						{
+							Name:       "instance",
+							Datasource: "${datasource}",
+							Type:       "query",
+							Label:      "instance",
+							Multi:      true,
+							AllValue:   ".+",
+						},
+					},
+				},
+			},
+		},
+	} {
+		testRule(t, linter, tc.dashboard, tc.result)
+	}
+}

--- a/lint/rule_template_job.go
+++ b/lint/rule_template_job.go
@@ -7,7 +7,7 @@ import (
 func NewTemplateJobRule() *DashboardRuleFunc {
 	return &DashboardRuleFunc{
 		name:        "template-job-rule",
-		description: "Checks that the dashboard has a templated job and instance.",
+		description: "Checks that the dashboard has a templated job.",
 		fn: func(d Dashboard) Result {
 			template := getTemplateDatasource(d)
 			if template == nil || template.Query != Prometheus {
@@ -15,10 +15,6 @@ func NewTemplateJobRule() *DashboardRuleFunc {
 			}
 
 			if r := checkTemplate(d, "job"); r != nil {
-				return *r
-			}
-
-			if r := checkTemplate(d, "instance"); r != nil {
 				return *r
 			}
 

--- a/lint/rule_template_job_test.go
+++ b/lint/rule_template_job_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestJobDatasource(t *testing.T) {
+func TestJobTemplate(t *testing.T) {
 	linter := NewTemplateJobRule()
 
 	for _, tc := range []struct {
@@ -111,34 +111,6 @@ func TestJobDatasource(t *testing.T) {
 							Datasource: "$datasource",
 							Type:       "query",
 							Label:      "bar",
-						},
-					},
-				},
-			},
-		},
-		// Missing instance templates.
-		{
-			result: Result{
-				Severity: Error,
-				Message:  "Dashboard 'test' is missing the instance template",
-			},
-			dashboard: Dashboard{
-				Title: "test",
-				Templating: struct {
-					List []Template `json:"list"`
-				}{
-					List: []Template{
-						{
-							Type:  "datasource",
-							Query: "prometheus",
-						},
-						{
-							Name:       "job",
-							Datasource: "$datasource",
-							Type:       "query",
-							Label:      "job",
-							Multi:      true,
-							AllValue:   ".+",
 						},
 					},
 				},

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -85,6 +85,7 @@ func NewRuleSet() RuleSet {
 		rules: []Rule{
 			NewTemplateDatasourceRule(),
 			NewTemplateJobRule(),
+			NewTemplateInstanceRule(),
 			NewTemplateLabelPromQLRule(),
 			NewPanelDatasourceRule(),
 			NewTargetPromQLRule(),


### PR DESCRIPTION
In some cases we want to ignore separately the job and the instance
template rule check. For instance, in dynamic environment where the
exporter could be relocated you may not want to have a instance template
in your dashboard (but you still want a job template)!

Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>