### PR TITLE
Account for `custom` type of template

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -68,8 +68,8 @@ func (t *Template) UnmarshalJSON(buf []byte) error {
 	t.Current = raw.Current
 	t.Options = raw.Options
 
-	// the 'adhoc' variable type does not have a field `Query`, so we can't perform these checks for the `adhoc` type
-	if t.Type != "adhoc" {
+	// the 'adhoc' and 'custom' variable type does not have a field `Query`, so we can't perform these checks
+	if t.Type != "adhoc" && t.Type != "custom" {
 		switch v := raw.Query.(type) {
 		case string:
 			t.Query = v

--- a/lint/testdata/dashboard.json
+++ b/lint/testdata/dashboard.json
@@ -71,6 +71,25 @@
         "name": "query0",
         "skipUrlSync": false,
         "type": "adhoc"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "10",
+          "value": "10"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "limit",
+        "options": [
+          {
+            "selected": true,
+            "text": "10",
+            "value": "10"
+          }
+        ],
+        "type": "custom"
       }
     ]
   },


### PR DESCRIPTION
Templates with type `custom` can contain a hardcoded set of options and run no queries. 

The linter reports this as an error:

```
invalid type for field 'query': <nil>
invalid type for field 'query': <nil>
2022/06/03 11:26:03 failed to lint the file mixin.libsonnet: 2 lint errors found
```