### PR TITLE
Support auto interval variables

### DIFF
--- a/lint/rule_target_promql_test.go
+++ b/lint/rule_target_promql_test.go
@@ -118,6 +118,18 @@ func TestTargetPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			result: ResultSuccess,
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: `increase(foo{}[$sampling])`,
+					},
+				},
+			},
+		},
 	} {
 		dashboard := Dashboard{
 			Title: "dashboard",
@@ -135,6 +147,11 @@ func TestTargetPromQLRule(t *testing.T) {
 						Options: []TemplateOption{
 							{TemplateValue: TemplateValue{Value: "1h"}, Selected: true},
 						},
+					},
+					{
+						Type:    "interval",
+						Name:    "sampling",
+						Current: TemplateValue{Value: "$__auto_interval_sampling"},
 					},
 					{
 						Type: "resolution",

--- a/lint/variables_test.go
+++ b/lint/variables_test.go
@@ -153,6 +153,22 @@ func TestVariableExpansion(t *testing.T) {
 			},
 			result: "max by(value) (rate(cpu{}[4h:5m]))",
 		},
+		{
+			desc: "Should recursively replace variables",
+			expr: "sum (rate(cpu{}[$interval]))",
+			variables: []Template{
+				{Name: "interval", Current: TemplateValue{Value: "$__auto_interval_interval"}},
+			},
+			result: "sum (rate(cpu{}[10s]))",
+		},
+		{
+			desc: "Should recursively replace variables, but not run into an infinite loop",
+			expr: "sum (rate(cpu{}[$interval]))",
+			variables: []Template{
+				{Name: "interval", Current: TemplateValue{Value: "$interval"}},
+			},
+			result: "sum (rate(cpu{}[interval]))",
+		},
 	} {
 		s, err := expandVariables(tc.expr, tc.variables)
 		require.Equal(t, tc.err, err)


### PR DESCRIPTION
Hello,

One of my colleague reported another interesting case... When using "auto" option for interval variables, the variable definition is not a valid value but $__auto_interval_xxxx.
So I added support for this by:
 - recursively expanding variables (which might not be needed in other cases, but I can't tell for sure)
 - replacing all `__auto_interval` variable with a 10s magic number

Let me know if you have questions/remarks,
Gabriel