### PR TITLE
Add panel missing title description rule

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -158,9 +158,9 @@ type Target struct {
 // Panel is a deliberately incomplete representation of the Dashboard -> Panel type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Panel struct {
-  Id          int        `json:"id"`
+	Id          int         `json:"id"`
 	Title       string      `json:"title"`
-  Description string     `json:"description"`
+	Description string      `json:"description"`
 	Targets     []Target    `json:"targets,omitempty"`
 	Datasource  Datasource  `json:"datasource"`
 	Type        string      `json:"type"`

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -158,11 +158,13 @@ type Target struct {
 // Panel is a deliberately incomplete representation of the Dashboard -> Panel type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Panel struct {
-	Title      string     `json:"title"`
-	Targets    []Target   `json:"targets,omitempty"`
-	Datasource Datasource `json:"datasource"`
-	Type       string     `json:"type"`
-	Panels     []Panel    `json:"panels,omitempty"`
+	Id          int        `json:"id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Targets     []Target   `json:"targets,omitempty"`
+	Datasource  Datasource `json:"datasource"`
+	Type        string     `json:"type"`
+	Panels      []Panel    `json:"panels,omitempty"`
 }
 
 // GetPanels returns the all panels nested inside the panel (inc the current panel)

--- a/lint/rule_panel_title_description.go
+++ b/lint/rule_panel_title_description.go
@@ -1,0 +1,23 @@
+package lint
+
+import "fmt"
+
+func NewPanelTitleDescriptionRule() *PanelRuleFunc {
+
+	return &PanelRuleFunc{
+		name:        "panel-title-description-rule",
+		description: "Checks that each panel has a title and description.",
+		fn: func(d Dashboard, p Panel) Result {
+			switch p.Type {
+			case "stat", "singlestat", "graph", "table", "timeseries", "gauge":
+				if len(p.Title) == 0 || len(p.Description) == 0 {
+					return Result{
+						Severity: Error,
+						Message:  fmt.Sprintf("Dashboard '%s', panel with id '%v' has missing title or description, currently has title '%s' and description: '%s'", d.Title, p.Id, p.Title, p.Description),
+					}
+				}
+			}
+			return ResultSuccess
+		},
+	}
+}

--- a/lint/rule_panel_title_description_test.go
+++ b/lint/rule_panel_title_description_test.go
@@ -1,0 +1,43 @@
+package lint
+
+import (
+	"testing"
+)
+
+func TestPanelTitleDescription(t *testing.T) {
+	linter := NewPanelTitleDescriptionRule()
+
+	for _, tc := range []struct {
+		result Result
+		panel  Panel
+	}{
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test', panel with id '1' has missing title or description, currently has title '' and description: ''",
+			},
+			panel: Panel{
+				Type:        "singlestat",
+				Id:          1,
+				Datasource:  "foo",
+				Title:       "",
+				Description: "",
+			},
+		},
+		{
+			result: Result{
+				Severity: Success,
+				Message:  "OK",
+			},
+			panel: Panel{
+				Type:        "singlestat",
+				Id:          1,
+				Datasource:  "foo",
+				Title:       "testpanel",
+				Description: "testdescription",
+			},
+		},
+	} {
+		testRule(t, linter, Dashboard{Title: "test", Panels: []Panel{tc.panel}}, tc.result)
+	}
+}

--- a/lint/rule_panel_title_description_test.go
+++ b/lint/rule_panel_title_description_test.go
@@ -19,9 +19,32 @@ func TestPanelTitleDescription(t *testing.T) {
 			panel: Panel{
 				Type:        "singlestat",
 				Id:          1,
-				Datasource:  "foo",
 				Title:       "",
 				Description: "",
+			},
+		},
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test', panel with id '2' has missing title or description, currently has title 'title' and description: ''",
+			},
+			panel: Panel{
+				Type:        "singlestat",
+				Id:          2,
+				Title:       "title",
+				Description: "",
+			},
+		},
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test', panel with id '3' has missing title or description, currently has title '' and description: 'description'",
+			},
+			panel: Panel{
+				Type:        "singlestat",
+				Id:          3,
+				Title:       "",
+				Description: "description",
 			},
 		},
 		{

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -88,6 +88,7 @@ func NewRuleSet() RuleSet {
 			NewTemplateInstanceRule(),
 			NewTemplateLabelPromQLRule(),
 			NewPanelDatasourceRule(),
+			NewPanelTitleDescriptionRule(),
 			NewTargetPromQLRule(),
 			NewTargetRateIntervalRule(),
 			NewTargetJobRule(),


### PR DESCRIPTION
This rule ensures that each panel has a non empty title and description.

Reference issue:
https://github.com/grafana/dashboard-linter/issues/54

Using panel ID when reporting the panel with missing title or description because if a panel has missing title then the only way to reference that panel is through the panel ID which is always generated (Would be hard to track that in jsonnet based dashboards)

Rule output:
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/17196882/175128955-2ea4e0de-cb0d-4348-8ae4-e64d24759878.png">
