### PR TITLE
Update promql valid rule

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -151,8 +151,10 @@ func (d *Datasource) UnmarshalJSON(buf []byte) error {
 // Target is a deliberately incomplete representation of the Dashboard -> Panel -> Target type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Target struct {
-	Idx  int    // This is the only (best?) way to uniquely identify a target, it is set by
-	Expr string `json:"expr,omitempty"`
+	Idx     int    // This is the only (best?) way to uniquely identify a target, it is set by
+	Expr    string `json:"expr,omitempty"`
+	PanelId int    `json:"panelId,omitempty"`
+	RefId   string `json:"refId,omitempty"`
 }
 
 // Panel is a deliberately incomplete representation of the Dashboard -> Panel type in grafana.
@@ -196,7 +198,9 @@ func (o *OverrideProperty) UnmarshalJSON(buf []byte) error {
 			Value int    `json:"value"`
 		}
 		if err := json.Unmarshal(buf, &raw); err != nil {
-			return err
+			// Overrirde can have varying different types int, string and arrays
+			// Currently only units are being changed from overrides so returning nil in case of unhandled types
+			return nil
 		}
 	}
 

--- a/lint/rule_target_promql.go
+++ b/lint/rule_target_promql.go
@@ -59,7 +59,7 @@ func NewTargetPromQLRule() *TargetRuleFunc {
 					}
 					return Result{
 						Severity: Error,
-						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid panel refernce in target, reference panel id '%d': ", d.Title, p.Title, t.PanelId),
+						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid panel refernce in target, reference panel id: '%d'", d.Title, p.Title, t.PanelId),
 					}
 				}
 			}

--- a/lint/rule_target_promql.go
+++ b/lint/rule_target_promql.go
@@ -33,6 +33,8 @@ func parsePromQL(expr string, variables []Template) (parser.Expr, error) {
 // NewTargetPromQLRule builds a lint rule for panels with Prometheus queries which checks:
 // - the query is valid PromQL
 // - the query contains two matchers within every selector - `{job=~"$job", instance=~"$instance"}`
+// - the query is not empty
+// - if the query references another panel then make sure that panel exists
 func NewTargetPromQLRule() *TargetRuleFunc {
 	return &TargetRuleFunc{
 		name:        "target-promql-rule",
@@ -45,6 +47,21 @@ func NewTargetPromQLRule() *TargetRuleFunc {
 
 			if !panelHasQueries(p) {
 				return ResultSuccess
+			}
+
+			// If panel does not contain an expression then check if it references another panel and it exists
+			if !(len(t.Expr) > 0) {
+				if t.PanelId > 0 {
+					for _, p1 := range d.Panels {
+						if p1.Id == t.PanelId {
+							return ResultSuccess
+						}
+					}
+					return Result{
+						Severity: Error,
+						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' invalid panel refernce in target, reference panel id '%d': ", d.Title, p.Title, t.PanelId),
+					}
+				}
 			}
 
 			if _, err := parsePromQL(t.Expr, d.Templating.List); err != nil {

--- a/lint/rule_target_promql_test.go
+++ b/lint/rule_target_promql_test.go
@@ -118,6 +118,7 @@ func TestTargetPromQLRule(t *testing.T) {
 				},
 			},
 		},
+		// Template variables substitutions
 		{
 			result: ResultSuccess,
 			panel: Panel{
@@ -125,7 +126,40 @@ func TestTargetPromQLRule(t *testing.T) {
 				Type:  "singlestat",
 				Targets: []Target{
 					{
-						Expr: `increase(foo{}[$sampling])`,
+						Expr: `sum (rate(foo[$interval:$resolution]))`,
+					},
+				},
+			},
+		},
+		// Empty PromQL expression
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel' invalid PromQL query '': 1:1: parse error: no expression found in input",
+			},
+			panel: Panel{
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						Expr: ``,
+					},
+				},
+			},
+		},
+		// Reference another panel that does not exist
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel' invalid panel refernce in target, reference panel id: '2'",
+			},
+			panel: Panel{
+				Id:    1,
+				Title: "panel",
+				Type:  "singlestat",
+				Targets: []Target{
+					{
+						PanelId: 2,
 					},
 				},
 			},


### PR DESCRIPTION
Updates promql valid rule:
- Allow panels with targets that reference another panel
- Check if a panel references another panel in target - it should exist
- Add test for empty promql expression