### PR TITLE
Add target histogram rule

### DIFF
--- a/lint/rule_target_histogram.go
+++ b/lint/rule_target_histogram.go
@@ -1,0 +1,61 @@
+package lint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func NewTargetHistogramRule() *TargetRuleFunc {
+	return &TargetRuleFunc{
+		name:        "target-histogram-rule",
+		description: "Checks that any bucket metric (ending in _bucket) is calculated with histogram.",
+		fn: func(d Dashboard, p Panel, t Target) Result {
+			expr, err := parsePromQL(t.Expr, d.Templating.List)
+			if err != nil {
+				// Invalid PromQL is another rule
+				return ResultSuccess
+			}
+
+			err = parser.Walk(inspector(func(node parser.Node, parents []parser.Node) error {
+				// We're looking for either a VectorSelector. This skips any other node type.
+				selector, ok := node.(*parser.VectorSelector)
+				if !ok {
+					return nil
+				}
+
+				errmsg := fmt.Errorf("Dashboard '%s', panel '%s', target idx '%d' histogram metric '%s' is not calculated in a histogram function", d.Title, p.Title, t.Idx, node.String())
+
+				if strings.HasSuffix(selector.String(), "_bucket") {
+					// The vector selector must have (at least) one parent
+					if len(parents) == 0 {
+						return errmsg
+					}
+
+					// Just reverse walk the stack of parents and return success if we find a histogram_quantile call
+					currentParent := len(parents) - 1
+					for currentParent >= 0 {
+						call, ok := parents[currentParent].(*parser.Call)
+						currentParent -= 1
+						if !ok {
+							continue
+						}
+						if call.Func.Name == "histogram_quantile" {
+							return nil
+						}
+					}
+					return errmsg
+				}
+				return nil
+			}), expr, nil)
+			if err != nil {
+				return Result{
+					Severity: Error,
+					Message:  err.Error(),
+				}
+			}
+			return ResultSuccess
+		},
+	}
+}

--- a/lint/rule_target_histogram.go
+++ b/lint/rule_target_histogram.go
@@ -27,7 +27,7 @@ func NewTargetHistogramRule() *TargetRuleFunc {
 
 				errmsg := fmt.Errorf("Dashboard '%s', panel '%s', target idx '%d' histogram metric '%s' is not calculated in a histogram function", d.Title, p.Title, t.Idx, node.String())
 
-				if strings.HasSuffix(selector.String(), "_bucket") {
+				if strings.Contains(selector.String(), "_bucket") {
 					// The vector selector must have (at least) one parent
 					if len(parents) == 0 {
 						return errmsg

--- a/lint/rule_target_histogram_test.go
+++ b/lint/rule_target_histogram_test.go
@@ -1,0 +1,69 @@
+package lint
+
+import (
+	"testing"
+)
+
+func TestTargetHistogramRule(t *testing.T) {
+	linter := NewTargetHistogramRule()
+
+	for _, tc := range []struct {
+		result Result
+		panel  Panel
+	}{
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel '', target idx '0' histogram metric 'something_bucket' is not calculated in a histogram function",
+			},
+			panel: Panel{
+				Targets: []Target{
+					{
+						Expr: `something_bucket`,
+					},
+				},
+			},
+		},
+		// Is this one valid? Would someone ever do this, or must there always be a rate?
+		{
+			result: ResultSuccess,
+			panel: Panel{
+				Targets: []Target{
+					{
+						Expr: `histogram_quantile(0.9, something_bucket)`,
+					},
+				},
+			},
+		},
+		{
+			result: ResultSuccess,
+			panel: Panel{
+				Targets: []Target{
+					{
+						Expr: `histogram_quantile(0.9, rate(something_bucket[$__rate_interval]))`,
+					},
+				},
+			},
+		},
+		{
+			result: ResultSuccess,
+			panel: Panel{
+				Targets: []Target{
+					{
+						Expr: `histogram_quantile(0.9, sum by (le) (rate(something_bucket[$__rate_interval])))`,
+					},
+				},
+			},
+		},
+	} {
+		dashboard := Dashboard{
+			Title: "dashboard",
+			Templating: struct {
+				List []Template "json:\"list\""
+			}{List: []Template{}},
+			Panels: []Panel{tc.panel},
+		}
+
+		testRule(t, linter, dashboard, tc.result)
+	}
+}

--- a/lint/rule_target_histogram_test.go
+++ b/lint/rule_target_histogram_test.go
@@ -24,7 +24,19 @@ func TestTargetHistogramRule(t *testing.T) {
 				},
 			},
 		},
-		// Is this one valid? Would someone ever do this, or must there always be a rate?
+		{
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel '', target idx '0' histogram metric 'job_cluster_le:something_bucket:rate_5m' is not calculated in a histogram function",
+			},
+			panel: Panel{
+				Targets: []Target{
+					{
+						Expr: `job_cluster_le:something_bucket:rate_5m`,
+					},
+				},
+			},
+		},
 		{
 			result: ResultSuccess,
 			panel: Panel{
@@ -51,6 +63,16 @@ func TestTargetHistogramRule(t *testing.T) {
 				Targets: []Target{
 					{
 						Expr: `histogram_quantile(0.9, sum by (le) (rate(something_bucket[$__rate_interval])))`,
+					},
+				},
+			},
+		},
+		{
+			result: ResultSuccess,
+			panel: Panel{
+				Targets: []Target{
+					{
+						Expr: `histogram_quantile(0.9, job_cluster_le:something_bucket:rate_5m)`,
 					},
 				},
 			},


### PR DESCRIPTION
Resolves #56.

Fairly simple, and literal check that finds any metric/series containing `_bucket` and ensures that it is inside of a function call to `histogram_quantile`.

There was some internal slack discussion about forthcoming features which may need to be accounted for in the future, but we will wait until those are finalized before addressing them in the rules.