### PR TITLE
Report rules in sorted order

### DIFF
--- a/lint/results.go
+++ b/lint/results.go
@@ -88,9 +88,16 @@ func (rs *ResultSet) ByRule() map[string][]ResultContext {
 }
 
 func (rs *ResultSet) ReportByRule() {
-	for _, res := range rs.ByRule() {
-		fmt.Fprintln(os.Stdout, res[0].Rule.Description())
-		for _, r := range res {
+	byRule := rs.ByRule()
+	rules := make([]string, 0, len(byRule))
+	for r := range byRule {
+		rules = append(rules, r)
+	}
+	sort.Strings(rules)
+
+	for _, rule := range rules {
+		fmt.Fprintln(os.Stdout, byRule[rule][0].Rule.Description())
+		for _, r := range byRule[rule] {
 			if r.Result.Severity == Exclude && !rs.config.Verbose {
 				continue
 			}


### PR DESCRIPTION
Resolves https://github.com/grafana/dashboard-linter/issues/39.
 
The fix involves sorting the rules by name and then using this order to iterate over the rules and their associated results. The sorting for the results is already taken care of by `ByRule()`.

I didn't add any tests because the addition is comparable to the sorting being done in `ByRule()` for which there are no tests. 

Please let me know if you have any questions or any changes to suggest.