### PR TITLE
Allow custom name for the datasource template

### DIFF
--- a/lint/rule_panel_datasource.go
+++ b/lint/rule_panel_datasource.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"fmt"
+	"regexp"
 )
 
 func NewPanelDatasourceRule() *PanelRuleFunc {
@@ -11,7 +12,8 @@ func NewPanelDatasourceRule() *PanelRuleFunc {
 		fn: func(d Dashboard, p Panel) Result {
 			switch p.Type {
 			case "singlestat", "graph", "table", "timeseries":
-				if p.Datasource != "$datasource" && p.Datasource != "${datasource}" {
+				match, _ := regexp.MatchString("^\\${?.+}?", string(p.Datasource))
+				if !match {
 					return Result{
 						Severity: Error,
 						Message:  fmt.Sprintf("Dashboard '%s', panel '%s' does not use templates datasource, uses '%s'", d.Title, p.Title, p.Datasource),

--- a/lint/rule_panel_datasource_test.go
+++ b/lint/rule_panel_datasource_test.go
@@ -34,6 +34,26 @@ func TestPanelDatasource(t *testing.T) {
 				Datasource: "$datasource",
 			},
 		},
+		{
+            result: Result{
+                Severity: Success,
+                Message:  "OK",
+            },
+            panel: Panel{
+                Type:       "singlestat",
+                Datasource: "${SomeDataSource}",
+            },
+        },
+        {
+            result: Result{
+                Severity: Success,
+                Message:  "OK",
+            },
+            panel: Panel{
+                Type:       "singlestat",
+                Datasource: "$SomeDataSource",
+            },
+        },
 	} {
 		testRule(t, linter, Dashboard{Title: "test", Panels: []Panel{tc.panel}}, tc.result)
 	}


### PR DESCRIPTION
Changed the datasource linter to allow any name for the datasource template using regexp.