### PR TITLE
Dasomeone/add alert lint exclusion prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_intermediate
-
+.idea
+.DS_store

--- a/lint/configuration.go
+++ b/lint/configuration.go
@@ -30,6 +30,8 @@ type ConfigurationEntry struct {
 	Reason    string `json:"reason,omitempty"`
 	Dashboard string `json:"dashboard,omitempty"`
 	Panel     string `json:"panel,omitempty"`
+	// Alerts are currently included, so we can read in configuration for Mixtool.
+	Alert string `json:"alert,omitempty"`
 	// This gets (un)marshalled as a string, because a 0 index is valid, but also the zero value of an int
 	TargetIdx string `json:"targetIdx"`
 }


### PR DESCRIPTION
This PR adds an additional field to the `ConfigurationEntry` struct, allowing for `Alert` overrides to be defined in the .lint config files.

The related lint exclusion logic will be contained entirely within Mixtool for the time being, as that is where the alert rules are enforced.

Additionally the .gitignore file has been updated to ignore standard IntelliJ IDEA artefacts