### PR TITLE
Config Flag Support

### DIFF
--- a/lint/configuration.go
+++ b/lint/configuration.go
@@ -3,7 +3,6 @@ package lint
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	yaml "gopkg.in/yaml.v3"
@@ -119,8 +118,7 @@ func NewConfigurationFile() *ConfigurationFile {
 }
 
 func (cf *ConfigurationFile) Load(path string) error {
-	lintFilePath := filepath.Join(path, ".lint")
-	f, err := os.Open(lintFilePath)
+	f, err := os.Open(path)
 	if err != nil && os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
@@ -130,7 +128,7 @@ func (cf *ConfigurationFile) Load(path string) error {
 
 	dec := yaml.NewDecoder(f)
 	if err = dec.Decode(cf); err != nil {
-		return fmt.Errorf("could not unmarshal lint configuration %s: %w", lintFilePath, err)
+		return fmt.Errorf("could not unmarshal lint configuration %s: %w", path, err)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -11,7 +10,9 @@ import (
 	"github.com/grafana/dashboard-linter/lint"
 )
 
-var lintStrictFlag, lintVerboseFlag bool
+var lintStrictFlag bool
+var lintVerboseFlag bool
+var lintConfigFlag string
 
 // lintCmd represents the lint command
 var lintCmd = &cobra.Command{
@@ -36,7 +37,7 @@ var lintCmd = &cobra.Command{
 		}
 
 		config := lint.NewConfigurationFile()
-		if err := config.Load(path.Dir(filename)); err != nil {
+		if err := config.Load(lintConfigFlag); err != nil {
 			return fmt.Errorf("failed to load lint config: %v", err)
 		}
 		config.Verbose = lintVerboseFlag
@@ -84,6 +85,13 @@ func init() {
 		"verbose",
 		false,
 		"show more information about linting",
+	)
+	lintCmd.Flags().StringVarP(
+		&lintConfigFlag,
+		"config",
+		"c",
+		"",
+		"path to a configuration file",
 	)
 }
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,6 +35,11 @@ var lintCmd = &cobra.Command{
 		dashboard, err := lint.NewDashboard(buf)
 		if err != nil {
 			return fmt.Errorf("failed to parse dashboard: %v", err)
+		}
+
+		// if no config flag was passed, set a default path of a .lint file in the dashboards directory
+		if lintConfigFlag == "" {
+			lintConfigFlag = path.Join(path.Dir(filename), ".lint")
 		}
 
 		config := lint.NewConfigurationFile()


### PR DESCRIPTION
Added the ability for the config flag to be specified as a flag (`--config` or `-c`).  When maintaining a repository of many dashboards / directories, it doesn't make sense to maintain multiple `.lint` files and instead have a config in the root of the repo. 