### PR TITLE
add rule for legend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,20 @@ clean-docs:
 clean: clean-docs
 
 update-docs: intermediate-docs embedmd
-	@./scripts/replace-rulenames-with-doclinks.sh	
+	@./scripts/replace-rulenames-with-doclinks.sh
 	@embedmd -w ./docs/index.md
 
 intermediate-docs:
 	@mkdir -p ./docs/_intermediate
 	@go run ./main.go -h > ./docs/_intermediate/help.txt
-	@go run ./main.go completion -h > ./docs/_intermediate/completion.txt	
+	@go run ./main.go completion -h > ./docs/_intermediate/completion.txt
 	@go run ./main.go lint -h > ./docs/_intermediate/lint.txt
 	@go run ./main.go rules > ./docs/_intermediate/rules.txt
 	@echo "Can't automate everything, please replace the #Rules section of index.md with the contents of ./docs/_intermediate/rules.txt"
 
 embedmd:
 	@go install github.com/campoy/embedmd@v1.0.0
+
+test:
+	@go test ./...
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/text v0.8.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -42,7 +43,6 @@ require (
 	go.uber.org/goleak v1.2.1 // indirect
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
 	google.golang.org/protobuf v1.29.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -155,10 +155,11 @@ func (d *Datasource) UnmarshalJSON(buf []byte) error {
 // Target is a deliberately incomplete representation of the Dashboard -> Panel -> Target type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Target struct {
-	Idx     int    // This is the only (best?) way to uniquely identify a target, it is set by
-	Expr    string `json:"expr,omitempty"`
-	PanelId int    `json:"panelId,omitempty"`
-	RefId   string `json:"refId,omitempty"`
+	Idx          int    // This is the only (best?) way to uniquely identify a target, it is set by
+	Expr         string `json:"expr,omitempty"`
+	PanelId      int    `json:"panelId,omitempty"`
+	RefId        string `json:"refId,omitempty"`
+	LegendFormat string `json:"legendFormat,omitempty"`
 }
 
 // Panel is a deliberately incomplete representation of the Dashboard -> Panel type in grafana.

--- a/lint/rule_legend.go
+++ b/lint/rule_legend.go
@@ -1,0 +1,34 @@
+package lint
+
+import (
+	"fmt"
+	"strings"
+)
+
+const legendPrefix = "{{instance}} - "
+
+func NewLegendRule() *TargetRuleFunc {
+	matcher := "foo"
+	return &TargetRuleFunc{
+		name:        fmt.Sprintf("target-%s-rule", matcher),
+		description: fmt.Sprintf("Checks that every PromQL query has a %s matcher.", matcher),
+		fn: func(d Dashboard, p Panel, t Target) Result {
+			switch p.Type {
+			case "stat", "singlestat", "graph", "table", "timeseries", "gauge", "barchart", "bargauge", "piechart", "histogram":
+				break
+			default:
+				return ResultSuccess
+			}
+
+			l := t.LegendFormat
+			if l == "" {
+				return NewErrorResult(d, p, t, fmt.Sprintf("Legend is missing - should start with '%s'", legendPrefix))
+			}
+			if strings.HasPrefix(l, legendPrefix) {
+				return ResultSuccess
+			} else {
+				return NewErrorResult(d, p, t, fmt.Sprintf("Legend should start with '%s' - found '%s'", legendPrefix, l))
+			}
+		},
+	}
+}

--- a/lint/rule_legend_test.go
+++ b/lint/rule_legend_test.go
@@ -1,0 +1,56 @@
+package lint
+
+import (
+	"testing"
+)
+
+func TestLegendRule(t *testing.T) {
+	linter := NewLegendRule()
+
+	for _, tc := range []struct {
+		name   string
+		result Result
+		target Target
+	}{
+		{
+			name:   "Happy path",
+			result: ResultSuccess,
+			target: Target{
+				LegendFormat: "{{instance}} - CPU utilization",
+			},
+		},
+		{
+			name: "missing legend",
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel', target idx '0' Legend is missing - should start with '{{instance}} - '",
+			},
+			target: Target{},
+		},
+		{
+			name: "wrong legend",
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'dashboard', panel 'panel', target idx '0' Legend should start with '{{instance}} - ' - found 'CPU utilization'",
+			},
+			target: Target{
+				LegendFormat: "CPU utilization",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dashboard := Dashboard{
+				Title: "dashboard",
+				Panels: []Panel{
+					{
+						Title:   "panel",
+						Type:    "singlestat",
+						Targets: []Target{tc.target},
+					},
+				},
+			}
+
+			testRule(t, linter, dashboard, tc.result)
+		})
+	}
+}

--- a/lint/rule_target_counter_agg.go
+++ b/lint/rule_target_counter_agg.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -25,7 +26,8 @@ func NewTargetCounterAggRule() *TargetRuleFunc {
 					return nil
 				}
 
-				errmsg := fmt.Errorf("Dashboard '%s', panel '%s', target idx '%d' counter metric '%s' is not aggregated with rate, irate, or increase", d.Title, p.Title, t.Idx, node.String())
+				errmsg := errors.New(NewErrorMessage(d, p, t,
+					fmt.Sprintf("counter metric '%s' is not aggregated with rate, irate, or increase", node.String())))
 
 				if strings.HasSuffix(selector.String(), "_total") {
 					// The vector selector must have (at least) two parents

--- a/lint/rule_target_job_instance.go
+++ b/lint/rule_target_job_instance.go
@@ -28,10 +28,7 @@ func newTargetRequiredMatcherRule(matcher string) *TargetRuleFunc {
 
 			for _, selector := range parser.ExtractSelectors(node) {
 				if err := checkForMatcher(selector, matcher, labels.MatchRegexp, fmt.Sprintf("$%s", matcher)); err != nil {
-					return Result{
-						Severity: Error,
-						Message:  fmt.Sprintf("Dashboard '%s', panel '%s', target idx '%d' invalid PromQL query '%s': %v", d.Title, p.Title, t.Idx, t.Expr, err),
-					}
+					return NewErrorResult(d, p, t, fmt.Sprintf("invalid PromQL query '%s': %v", t.Expr, err))
 				}
 			}
 

--- a/lint/rule_target_promql.go
+++ b/lint/rule_target_promql.go
@@ -65,10 +65,7 @@ func NewTargetPromQLRule() *TargetRuleFunc {
 			}
 
 			if _, err := parsePromQL(t.Expr, d.Templating.List); err != nil {
-				return Result{
-					Severity: Error,
-					Message:  fmt.Sprintf("Dashboard '%s', panel '%s', target idx '%d' invalid PromQL query '%s': %v", d.Title, p.Title, t.Idx, t.Expr, err),
-				}
+				return NewErrorResult(d, p, t, fmt.Sprintf("invalid PromQL query '%s': %v", t.Expr, err))
 			}
 
 			return ResultSuccess

--- a/lint/rule_target_rate_interval.go
+++ b/lint/rule_target_rate_interval.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,7 +63,8 @@ func NewTargetRateIntervalRule() *TargetRuleFunc {
 				// Now check if the parent is a rate function
 				call, ok := parents[len(parents)-1].(*parser.Call)
 				if !ok {
-					return fmt.Errorf("Dashboard '%s', panel '%s', target idx '%d' invalid PromQL query '%s': $__rate_interval used in non-rate function", d.Title, p.Title, t.Idx, t.Expr)
+					return errors.New(NewErrorMessage(d, p, t, fmt.Sprintf(
+						"invalid PromQL query '%s': $__rate_interval used in non-rate function", t.Expr)))
 				}
 
 				if call.Func.Name != "rate" && call.Func.Name != "irate" {
@@ -70,7 +72,8 @@ func NewTargetRateIntervalRule() *TargetRuleFunc {
 					return nil
 				}
 
-				return fmt.Errorf("Dashboard '%s', panel '%s', target idx '%d' invalid PromQL query '%s': should use $__rate_interval", d.Title, p.Title, t.Idx, t.Expr)
+				return errors.New(NewErrorMessage(d, p, t,
+					fmt.Sprintf("invalid PromQL query '%s': should use $__rate_interval", t.Expr)))
 			}), expr, nil)
 			if err != nil {
 				return Result{

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -1,5 +1,7 @@
 package lint
 
+import "fmt"
+
 type Rule interface {
 	Description() string
 	Name() string
@@ -83,6 +85,7 @@ type RuleSet struct {
 func NewRuleSet() RuleSet {
 	return RuleSet{
 		rules: []Rule{
+			NewLegendRule(),
 			NewTemplateDatasourceRule(),
 			NewTemplateJobRule(),
 			NewTemplateInstanceRule(),
@@ -117,4 +120,15 @@ func (s *RuleSet) Lint(dashboards []Dashboard) (*ResultSet, error) {
 		}
 	}
 	return resSet, nil
+}
+
+func NewErrorResult(d Dashboard, p Panel, t Target, msg string) Result {
+	return Result{
+		Severity: Error,
+		Message:  NewErrorMessage(d, p, t, msg),
+	}
+}
+
+func NewErrorMessage(d Dashboard, p Panel, t Target, msg string) string {
+	return fmt.Sprintf("Dashboard '%s', panel '%s', target idx '%d' %s", d.Title, p.Title, t.Idx, msg)
 }


### PR DESCRIPTION
It's a good practice to prefix the legend with the instance ID, so that dashboards can show all instances, or only a selected one