### PR TITLE
Bugfix: `FieldConfig` not be present on a panel

### DIFF
--- a/lint/rule_panel_units.go
+++ b/lint/rule_panel_units.go
@@ -97,7 +97,7 @@ func getConfiguredUnit(p Panel) string {
 			}
 		}
 	}
-	if configuredUnit == "" && len(p.FieldConfig.Defaults.Unit) > 0 {
+	if configuredUnit == "" && p.FieldConfig != nil && len(p.FieldConfig.Defaults.Unit) > 0 {
 		configuredUnit = p.FieldConfig.Defaults.Unit
 	}
 	return configuredUnit

--- a/lint/rule_panel_units.go
+++ b/lint/rule_panel_units.go
@@ -88,7 +88,7 @@ func NewPanelUnitsRule() *PanelRuleFunc {
 func getConfiguredUnit(p Panel) string {
 	configuredUnit := ""
 	// First check if an override with unit exists - if no override then check if standard unit is present and valid
-	if len(p.FieldConfig.Overrides) > 0 {
+	if p.FieldConfig != nil && len(p.FieldConfig.Overrides) > 0 {
 		for _, p := range p.FieldConfig.Overrides {
 			for _, o := range p.OverrideProperties {
 				if o.Id == "unit" {

--- a/lint/rule_panel_units_test.go
+++ b/lint/rule_panel_units_test.go
@@ -30,7 +30,7 @@ func TestPanelUnits(t *testing.T) {
 			},
 		},
 		{
-			name: "missing unit",
+			name: "missing FieldConfig",
 			result: Result{
 				Severity: Error,
 				Message:  "Dashboard 'test', panel 'bar' has no or invalid units defined: ''",
@@ -39,6 +39,19 @@ func TestPanelUnits(t *testing.T) {
 				Type:       "singlestat",
 				Datasource: "foo",
 				Title:      "bar",
+			},
+		},
+		{
+			name: "empty FieldConfig",
+			result: Result{
+				Severity: Error,
+				Message:  "Dashboard 'test', panel 'bar' has no or invalid units defined: ''",
+			},
+			panel: Panel{
+				Type:        "singlestat",
+				Datasource:  "foo",
+				Title:       "bar",
+				FieldConfig: &FieldConfig{},
 			},
 		},
 		{

--- a/lint/rule_panel_units_test.go
+++ b/lint/rule_panel_units_test.go
@@ -36,10 +36,9 @@ func TestPanelUnits(t *testing.T) {
 				Message:  "Dashboard 'test', panel 'bar' has no or invalid units defined: ''",
 			},
 			panel: Panel{
-				Type:        "singlestat",
-				Datasource:  "foo",
-				Title:       "bar",
-				FieldConfig: &FieldConfig{},
+				Type:       "singlestat",
+				Datasource: "foo",
+				Title:      "bar",
 			},
 		},
 		{


### PR DESCRIPTION
When attempting to get the configured unit of a panel, there's a chance that the field configuration is not on the dashboard definition. We should nil check this property before we attempt to access it.

Looks like this was introduced in https://github.com/grafana/dashboard-linter/pull/127