### PR TITLE
Fix panic when decoding a template that doesn't have a query field.

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -77,7 +77,10 @@ func (t *Template) UnmarshalJSON(buf []byte) error {
 		case string:
 			t.Query = v
 		case map[string]interface{}:
-			t.Query = v[targetTypeQuery].(string)
+			query, ok := v[targetTypeQuery]
+			if ok {
+				t.Query = query.(string)
+			}
 		default:
 			return fmt.Errorf("invalid type for field 'query': %v", v)
 		}

--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -105,3 +105,22 @@ func TestParseTemplateValue(t *testing.T) {
 		require.Equal(t, tc.expected, actual)
 	}
 }
+
+func TestParseTemplate(t *testing.T) {
+	for _, tc := range []struct {
+		input    []byte
+		expected Template
+		err      error
+	}{
+		{
+			// NB no "query.query" field, some data source don't use this.
+			input:    []byte(`{ "type": "query", "query": {} }`),
+			expected: Template{Type: "query", RawQuery: map[string]interface{}{}},
+		},
+	} {
+		var actual Template
+		err := json.Unmarshal(tc.input, &actual)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, actual)
+	}
+}


### PR DESCRIPTION
e.g. googlecloud-logging-datasource; fixes #146.