### PR TITLE
fix: Strict thinks Quiet Sev is an error

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -11,9 +11,9 @@ type Severity int
 const (
 	Success Severity = iota
 	Exclude
+	Quiet
 	Warning
 	Error
-	Quiet
 	Fixed
 
 	Prometheus = "prometheus"


### PR DESCRIPTION
When run with `--strict` today an error is reported even if it is a quiet issue, this will move quiet under warning so that will not trigger anymore.

Fixed #156

Bug:

When you run the linter with --strict it reports failures even though from a ui perspective nothing is visible as a failure.

Analysis:

All of the Severity levels are iota based with Success being 0 and importantly Quiet being 4

https://github.com/grafana/dashboard-linter/blob/main/lint/lint.go#L11

The Results object is processed for MaximumSeverity and looks for the highest number based on iota: https://github.com/grafana/dashboard-linter/blob/main/lint/results.go#L160 which makes Quiet higher than the default Success so it is returned with the response of 4

Finally when strict is enabled, it will report errors for any level above Warning, https://github.com/grafana/dashboard-linter/blob/main/main.go#L91 which Quiet is, so errors are reported but they are not visible at all anywhere

Possible fixes:

1. Update the MaximumSeverity to ignore Quiet - This may give people surprises later 
2. Move Quiet to iota 1 so it will be: Success, Quiet, 
3. If in strict mode not return if the result = Quiet. - This has a flaw that today Quiet is considered a higher level than error so errors could be hidden from strict response

Chosen fix: 2 - Change the iota and validate other tests don't fail
