### PR TITLE
feat: added new units: mps, mpm (messages per sec/minute)

### DIFF
--- a/lint/rule_panel_units.go
+++ b/lint/rule_panel_units.go
@@ -54,7 +54,7 @@ func NewPanelUnitsRule() *PanelRuleFunc {
 		// Time
 		"hertz", "ns", "µs", "ms", "s", "m", "h", "d", "dtdurationms", "dtdurations", "dthms", "dtdhms", "timeticks", "clockms", "clocks",
 		// Throughput
-		"cps", "ops", "reqps", "rps", "wps", "iops", "cpm", "opm", "rpm", "wpm",
+		"cps", "ops", "reqps", "rps", "wps", "iops", "cpm", "opm", "rpm", "wpm", "mps", "mpm",
 		// Velocity
 		"velocityms", "velocitykmh", "velocitymph", "velocityknot",
 		// Volume


### PR DESCRIPTION
Hi,
We are using the messages/sec and messages/minute units, which are included in the newer versions of Grafana. I just added these to the list of approved units.