### PR TITLE
expand fields available to linter

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -125,36 +125,60 @@ func (raw *RawTemplateValue) Get() (TemplateValue, error) {
 	return t, nil
 }
 
-type Datasource string
+// Input is a deliberately incomplete representation of the Dashboard -> Input type in grafana.
+// The properties which are extracted from JSON are only those used for linting purposes.
+type Input struct {
+	Name     string `json:"name"`
+	Label    string `json:"label"`
+	Type     string `json:"type"`
+	PluginID string `json:"pluginId"`
+}
+
+type Datasource struct {
+	UID  string `json:"uid"`
+	Type string `json:"type"`
+}
 
 func GetDataSource(raw interface{}) (Datasource, error) {
 	switch v := raw.(type) {
 	case nil:
-		return "", nil
+		return Datasource{}, nil
 	case string:
-		return Datasource(v), nil
+		return Datasource{v, ""}, nil
 	case map[string]interface{}:
 		uid, ok := v["uid"]
 		if !ok {
-			return "", fmt.Errorf("invalid type for field 'datasource': missing uid field")
+			return Datasource{}, fmt.Errorf("invalid type for field 'datasource': missing uid field")
 		}
 		uidStr, ok := uid.(string)
 		if !ok {
-			return "", fmt.Errorf("invalid type for field 'datasource': invalid uid field type, should be string")
+			return Datasource{}, fmt.Errorf("invalid type for field 'datasource': invalid uid field type, should be string")
 		}
-		return Datasource(uidStr), nil
+		if dsType, ok := v["type"]; ok {
+			dsTypeStr, ok := dsType.(string)
+			if !ok {
+				return Datasource{}, fmt.Errorf("invalid type for field 'datasource': invalid type field type, should be string")
+			}
+			return Datasource{uidStr, dsTypeStr}, nil
+		}
+		return Datasource{uidStr, ""}, nil
 	default:
-		return "", fmt.Errorf("invalid type for field 'datasource': %v", v)
+		return Datasource{}, fmt.Errorf("invalid type for field 'datasource': %v", v)
 	}
 }
 
 // Target is a deliberately incomplete representation of the Dashboard -> Panel -> Target type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Target struct {
-	Idx     int    `json:"-"` // This is the only (best?) way to uniquely identify a target, it is set by GetPanels
-	Expr    string `json:"expr,omitempty"`
-	PanelId int    `json:"panelId,omitempty"`
-	RefId   string `json:"refId,omitempty"`
+	Idx        int         `json:"-"` // This is the only (best?) way to uniquely identify a target, it is set by GetPanels
+	Datasource interface{} `json:"datasource,omitempty"`
+	Expr       string      `json:"expr,omitempty"`
+	PanelId    int         `json:"panelId,omitempty"`
+	RefId      string      `json:"refId,omitempty"`
+}
+
+func (t *Target) GetDataSource() (Datasource, error) {
+	return GetDataSource(t.Datasource)
 }
 
 // Panel is a deliberately incomplete representation of the Dashboard -> Panel type in grafana.
@@ -242,7 +266,8 @@ func (r *Row) GetPanels() []Panel {
 // Dashboard is a deliberately incomplete representation of the Dashboard type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Dashboard struct {
-	Title      string `json:"title,omitempty"`
+	Inputs     []Input `json:"__inputs"`
+	Title      string  `json:"title,omitempty"`
 	Templating struct {
 		List []Template `json:"list"`
 	} `json:"templating"`

--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -21,12 +21,17 @@ func TestParseDatasource(t *testing.T) {
 		{
 			name:     "string",
 			input:    []byte(`"${datasource}"`),
-			expected: "${datasource}",
+			expected: Datasource{"${datasource}", ""},
 		},
 		{
 			name:     "uid",
 			input:    []byte(`{"uid":"${datasource}"}`),
-			expected: "${datasource}",
+			expected: Datasource{"${datasource}", ""},
+		},
+		{
+			name:     "uid-type",
+			input:    []byte(`{"uid":"${datasource}","type":"${type}"}`),
+			expected: Datasource{"${datasource}", "${type}"},
 		},
 		{
 			name:  "byte",

--- a/lint/rule_panel_datasource.go
+++ b/lint/rule_panel_datasource.go
@@ -25,9 +25,9 @@ func NewPanelDatasourceRule() *PanelRuleFunc {
 				if err != nil {
 					r.AddError(d, p, fmt.Sprintf("has invalid datasource: %v'", err))
 				}
-				_, ok := availableDsUids[string(src)]
+				_, ok := availableDsUids[string(src.UID)]
 				if !ok {
-					r.AddError(d, p, fmt.Sprintf("does not use a templated datasource, uses '%s'", src))
+					r.AddError(d, p, fmt.Sprintf("does not use a templated datasource, uses '%s'", src.UID))
 				}
 			}
 

--- a/lint/rule_template_job.go
+++ b/lint/rule_template_job.go
@@ -39,8 +39,9 @@ func checkTemplate(d Dashboard, name string, r *DashboardRuleResults) {
 		r.AddError(d, fmt.Sprintf("%s template has invalid datasource %v", name, err))
 	}
 
-	if src != "$datasource" && src != "${datasource}" && src != "$prometheus_datasource" && src != "${prometheus_datasource}" {
-		r.AddError(d, fmt.Sprintf("%s template should use datasource '$datasource', is currently '%s'", name, src))
+	srcUid := src.UID
+	if srcUid != "$datasource" && srcUid != "${datasource}" && srcUid != "$prometheus_datasource" && srcUid != "${prometheus_datasource}" {
+		r.AddError(d, fmt.Sprintf("%s template should use datasource '$datasource', is currently '%s'", name, srcUid))
 	}
 
 	if t.Type != targetTypeQuery {

--- a/lint/testdata/dashboard.json
+++ b/lint/testdata/dashboard.json
@@ -1,4 +1,12 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prom",
+      "type": "datasource",
+      "pluginId": "prom"
+    }
+  ],
   "rows": [
     {
       "panels": [


### PR DESCRIPTION
this expands the parsing logic to enable linting on additional fields in the dashboard schema:

- .__inputs
- .panels[].targets[].datasource

additionally, the datasource now will have a 'type' property available, if present in the dashboard model.

one target use-case for this is ensuring that datasources defined in panels and targets are referencing datasources defined in the __inputs section. the __inputs section is particularly important for dashboards exported for sharing w/ other grafana environments.