### PR TITLE
expose annotations to linter

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -181,6 +181,15 @@ func (t *Target) GetDataSource() (Datasource, error) {
 	return GetDataSource(t.Datasource)
 }
 
+type Annotation struct {
+	Name       string      `json:"name"`
+	Datasource interface{} `json:"datasource,omitempty"`
+}
+
+func (a *Annotation) GetDataSource() (Datasource, error) {
+	return GetDataSource(a.Datasource)
+}
+
 // Panel is a deliberately incomplete representation of the Dashboard -> Panel type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Panel struct {
@@ -271,6 +280,9 @@ type Dashboard struct {
 	Templating struct {
 		List []Template `json:"list"`
 	} `json:"templating"`
+	Annotations struct {
+		List []Annotation `json:"list"`
+	} `json:"annotations"`
 	Rows     []Row   `json:"rows,omitempty"`
 	Panels   []Panel `json:"panels,omitempty"`
 	Editable bool    `json:"editable,omitempty"`

--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -68,6 +68,11 @@ func TestParseDashboard(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, dashboard.GetPanels(), 4)
 	})
+	t.Run("Annotations", func(t *testing.T) {
+		dashboard, err := NewDashboard(sampleDashboard)
+		assert.NoError(t, err)
+		assert.Len(t, dashboard.Annotations.List, 1)
+	})
 }
 
 func TestParseTemplateValue(t *testing.T) {

--- a/lint/testdata/dashboard.json
+++ b/lint/testdata/dashboard.json
@@ -8,6 +8,21 @@
       "pluginId": "prom"
     }
   ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "rows": [
     {
       "panels": [


### PR DESCRIPTION
these are structured similarly to the 'templating' field, but in general do not reliably have a 'type' field exposed.

use-case for this is catching when datasources are defined in annotations but they're not derived from dashboard inputs.