### PR TITLE
fix loop var bug in fixable results

### DIFF
--- a/lint/rules.go
+++ b/lint/rules.go
@@ -26,6 +26,7 @@ func (f DashboardRuleFunc) Lint(d Dashboard, s *ResultSet) {
 	}
 	rr := make([]FixableResult, len(dashboardResults))
 	for i, r := range dashboardResults {
+		r := r // capture loop variable
 		var fix func(*Dashboard)
 		if r.Fix != nil {
 			fix = func(dashboard *Dashboard) {


### PR DESCRIPTION
when a rule has multiple fixable results, only the last fix function runs (but it runs once per fixable result.) this is due to the classic go loop var scoping behavior. there are other instances of this workaround in the codebase so this just copies that convention. eventually we can get rid of all of this when later versions of go have different behavior around loopvars[^0].

[^0]: https://go.dev/blog/loopvar-preview