### PR TITLE
expose id field to linter

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -267,6 +267,7 @@ func (r *Row) GetPanels() []Panel {
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Dashboard struct {
 	Inputs     []Input `json:"__inputs"`
+	ID         int     `json:"id"`
 	Title      string  `json:"title,omitempty"`
 	Templating struct {
 		List []Template `json:"list"`

--- a/lint/testdata/dashboard.json
+++ b/lint/testdata/dashboard.json
@@ -8,6 +8,7 @@
       "pluginId": "prom"
     }
   ],
+  "id": null,
   "rows": [
     {
       "panels": [


### PR DESCRIPTION
enables rules to look at the ID field. use-case for this is if you want to ensure IDs are not malformed, or perhaps set to the 0 value (so grafana will auto-assign).