### PR TITLE
Use more current golangci-lint, and fix an error it caught

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54
+          version: v1.61.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/lint/variables.go
+++ b/lint/variables.go
@@ -45,7 +45,7 @@ func stringValue(name string, value interface{}, kind, format string) (string, e
 			case "iso":
 				return val.Format(time.RFC3339), nil
 			default:
-				return "", fmt.Errorf("Unsupported momentjs time format: " + format)
+				return "", fmt.Errorf("Unsupported momentjs time format: %s", format)
 			}
 		default:
 			switch format {


### PR DESCRIPTION
#195 is failing due to the addition of loki, which adds several dependencies. golangci-lint didn't like the embedded interfaces on a loki object, among other things. Using a more current golangci-lint resolves those issues.