### PR TITLE
Keep searching for job/instance if multiple job/instance matchers present

### DIFF
--- a/lint/rule_target_job_instance_test.go
+++ b/lint/rule_target_job_instance_test.go
@@ -29,6 +29,19 @@ func testTargetRequiredMatcherRule(t *testing.T, matcher string) {
 				Expr: fmt.Sprintf(`sum(rate(foo{%s=~"$%s"}[5m]))`, matcher, matcher),
 			},
 		},
+		// Happy path (multiple matchers where at least one matches)
+		{
+			result: ResultSuccess,
+			target: Target{
+				Expr: fmt.Sprintf(`sum(rate(foo{%s="integrations/bar", %s=~"$%s"}[5m]))`, matcher, matcher, matcher),
+			},
+		},
+		{
+			result: ResultSuccess,
+			target: Target{
+				Expr: fmt.Sprintf(`sum(rate(foo{%s=~"$%s", %s="integrations/bar"}[5m]))`, matcher, matcher, matcher),
+			},
+		},
 		// Also happy when the promql is invalid
 		{
 			result: ResultSuccess,

--- a/lint/target_utils.go
+++ b/lint/target_utils.go
@@ -7,21 +7,26 @@ import (
 )
 
 func checkForMatcher(selector []*labels.Matcher, name string, ty labels.MatchType, value string) error {
+	var result error
+	result = fmt.Errorf("%s selector not found", name)
+
 	for _, matcher := range selector {
 		if matcher.Name != name {
 			continue
 		}
+		if matcher.Type == ty && matcher.Value == value {
+			result = nil
+			break
+		}
 
 		if matcher.Type != ty {
-			return fmt.Errorf("%s selector is %s, not %s", name, matcher.Type, ty)
+			result = fmt.Errorf("%s selector is %s, not %s", name, matcher.Type, ty)
 		}
 
 		if matcher.Value != value {
-			return fmt.Errorf("%s selector is %s, not %s", name, matcher.Value, value)
+			result = fmt.Errorf("%s selector is %s, not %s", name, matcher.Value, value)
 		}
-
-		return nil
 	}
 
-	return fmt.Errorf("%s selector not found", name)
+	return result
 }


### PR DESCRIPTION
This improvement would keep searching for job/instance matchers in PromQL query instead of failing on the first match.

In this case `[target-job-rule]` check would not fail if multiple job/instance matchers are present and expected value (i.e `job=~"$job"`) is within the second, not the first match.

This should fix it when job is present in both groupLabels and filteringSelector.

For example:

```
$instance"}': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'Disk C: size', target idx '0' invalid PromQL query 'windows_logical_disk_size_bytes{volume="C:", job=~".*windows.*",job=~"$job",instance=~"$instance"}': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'CPU usage', target idx '0' invalid PromQL query '100 - (avg without (mode,core) (rate(windows_cpu_time_total{mode="idle", job=~".*windows.*",job=~"$job",instance=~"$instance"}[$__rate_interval])*100))': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'CPU usage', target idx '0' invalid PromQL query '100 - (avg without (mode,core) (rate(windows_cpu_time_total{mode="idle", job=~".*windows.*",job=~"$job",instance=~"$instance"}[$__rate_interval])*100))': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'Memory usage', target idx '0' invalid PromQL query '100 - windows_os_physical_memory_free_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"} / windows_cs_physical_memory_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"} * 100': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'Memory usage', target idx '0' invalid PromQL query '100 - windows_os_physical_memory_free_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"} / windows_cs_physical_memory_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"} * 100': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'Memory usage', target idx '0' invalid PromQL query 'windows_cs_physical_memory_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"} - windows_os_physical_memory_free_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"}': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'Memory usage', target idx '0' invalid PromQL query 'windows_cs_physical_memory_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"} - windows_os_physical_memory_free_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"}': job selector is .*windows.*, not $job
[target-job-rule] 'Windows overview': Dashboard 'Windows overview', panel 'Memory usage', target idx '1' invalid PromQL query 'windows_cs_physical_memory_bytes{job=~".*windows.*",job=~"$job",instance=~"$instance"}': job selector is .*windows.*, not $job
```