### PR TITLE
K8s/G12: Support kubernetes wrapper metadata

### DIFF
--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -73,6 +73,19 @@ func TestParseDashboard(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, dashboard.Annotations.List, 1)
 	})
+
+	t.Run("v0alpha1 dashboard", func(t *testing.T) {
+		wrap := `{
+			"apiVersion": "v0alpha1",
+			"kind": "Dashboard",
+			"spec": ` + string(sampleDashboard) + `
+		}`
+
+		dashboard, err := NewDashboard([]byte(wrap))
+		assert.NoError(t, err)
+		assert.Len(t, dashboard.Annotations.List, 1)
+		assert.Equal(t, "v0alpha1", dashboard.APIVersion)
+	})
 }
 
 func TestParseTemplateValue(t *testing.T) {


### PR DESCRIPTION
In Grafana12 and beyond, the kubernetes api will be the default api for dashboards.  The resource object is essentially the current dashboard json shoved into the spec.
* https://github.com/grafana/grafana/blob/v11.3.1/pkg/apis/dashboard/v0alpha1/types.go#L11
* https://github.com/grafana/grafana/blob/main/pkg/apis/dashboard/v1alpha1/types.go#L11

We are also working on a v2 schema that will be much easier to lint/validate, but that is a different issue!

This PR updates the lint parser so it accepts either the classic dashboard json format, or a k8s wrapper.

FYI, we are using this tool as part of https://github.com/grafana/grafana/pull/96329 and it is excellent