### PR TITLE
unit-rule: Fix panic on grafonnet generated dashboards

### DIFF
--- a/lint/rule_panel_units.go
+++ b/lint/rule_panel_units.go
@@ -80,10 +80,7 @@ func NewPanelUnitsRule() *PanelRuleFunc {
 				if p.Type == "stat" {
 					var opts StatOptions
 					err := json.Unmarshal(p.Options, &opts)
-					if err != nil {
-						r.AddError(d, p, err.Error())
-					}
-					if hasReduceOptionsNonNumericFields(&opts.ReduceOptions) {
+					if err == nil && hasReduceOptionsNonNumericFields(&opts.ReduceOptions) {
 						return r
 					}
 				}
@@ -114,7 +111,7 @@ func getConfiguredUnit(p Panel) string {
 	if p.FieldConfig != nil && len(p.FieldConfig.Overrides) > 0 {
 		for _, p := range p.FieldConfig.Overrides {
 			for _, o := range p.Properties {
-				if o.Id == "unit" {
+				if o.Id == "unit" && o.Value != nil {
 					configuredUnit = o.Value.(string)
 				}
 			}
@@ -128,12 +125,15 @@ func getConfiguredUnit(p Panel) string {
 
 func getValueMappings(p Panel) []dashboard.ValueMapping {
 	valueMappings := make([]dashboard.ValueMapping, 0)
-	// First check if an override with unit exists - if no override then check if standard unit is present and valid
+	// First check if an override with value mapping exists - if no override then check if standard value mapping is present and valid
 	if p.FieldConfig != nil && len(p.FieldConfig.Overrides) > 0 {
 		for _, p := range p.FieldConfig.Overrides {
 			for _, o := range p.Properties {
 				if o.Id == "mappings" {
-					valueMappings = o.Value.([]dashboard.ValueMapping)
+					vm, ok := o.Value.([]dashboard.ValueMapping)
+					if ok {
+						valueMappings = vm
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Example:


```
panic: interface conversion: interface {} is []interface {}, not []dashboard.ValueMapOrRangeMapOrRegexMapOrSpecialValueMap

goroutine 1 [running]:
github.com/grafana/dashboard-linter/lint.getValueMappings(...)
        /home/code/go/pkg/mod/github.com/grafana/dashboard-linter@v0.0.0-20241203055812-9cec106fc01c/lint/rule_panel_units.go:136
github.com/grafana/dashboard-linter/lint.NewPanelUnitsRule.func1({{0x0, 0x0, 0x0}, {0xc00039e490, 0x10}, {{0xc00022c2c8, 0x3, 0x4}}, {{0x0, 0x0, ...}}, ...}, ...)
        /home/code/go/pkg/mod/github.com/grafana/dashboard-linter@v0.0.0-20241203055812-9cec106fc01c/lint/rule_panel_units.go:92 +0x6a5
github.com/grafana/dashboard-linter/lint.PanelRuleFunc.Lint({{0x1500a72, 0x10}, {0x1538a1c, 0x34}, 0xc0001130a0}, {{0x0, 0x0, 0x0}, {0xc00039e490, 0x10}, ...}, ...)
        /home/code/go/pkg/mod/github.com/grafana/dashboard-linter@v0.0.0-20241203055812-9cec106fc01c/lint/rules.go:69 +0x276
github.com/grafana/dashboard-linter/lint.(*RuleSet).Lint(0xc0001299c0, {0xc000129a00, 0x1, 0xc00039e490?})
        /home/code/go/pkg/mod/github.com/grafana/dashboard-linter@v0.0.0-20241203055812-9cec106fc01c/lint/rules.go:209 +0x127
main.init.func2(0xc0000ed700?, {0xc000543670?, 0x1?, 0x14f1b27?})
        /home/code/go/pkg/mod/github.com/grafana/dashboard-linter@v0.0.0-20241203055812-9cec106fc01c/main.go:73 +0x510
github.com/spf13/cobra.(*Command).execute(0x2125820, {0xc000543640, 0x1, 0x1})
        /home/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0x2125de0)
        /home/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/code/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
        /home/code/go/pkg/mod/github.com/grafana/dashboard-linter@v0.0.0-20241203055812-9cec106fc01c/main.go:176 +0x1a
```

when empty mapping is provided:


```
            "fieldConfig": {
               "overrides": [
                  {
                     "matcher": {
                        "id": "byName",
                        "options": "Topic start offset"
                     },
                     "properties": [
                        {
                           "id": "mappings",
                           "value": [ ]
                        },
                        {
                           "id": "unit",
                           "value": "none"
                        }
                     ]
                  },
...
```