### PR TITLE
Adds two new fields to the panel Override struct

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -213,6 +213,8 @@ type FieldConfig struct {
 
 type Override struct {
 	OverrideProperties []OverrideProperty `json:"properties"`
+	SystemRef          string             `json:"__systemRef,omitempty"`
+	Matcher            any                `json:"matcher,omitempty"`
 }
 
 type OverrideProperty struct {


### PR DESCRIPTION
These fields are applied when using a variable name matcher while creating an override in a panel. When autofix is enabled any overrides that have these fields will result in duplicated objects in the resulting dashboard JSON file.

fixes #223 