### PR TITLE
preserve index in GetTemplateByType

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -23,6 +23,7 @@ const (
 // Target is a deliberately incomplete representation of the Dashboard -> Template type in grafana.
 // The properties which are extracted from JSON are only those used for linting purposes.
 type Template struct {
+	Idx        int                `json:"-"` // This is the only (best?) way to uniquely identify a template, it is set by GetTemplateByType
 	Name       string             `json:"name"`
 	Label      string             `json:"label"`
 	Type       string             `json:"type"`
@@ -311,7 +312,8 @@ func (d *Dashboard) GetPanels() []Panel {
 // is case insensitive as it uses strings.EqualFold()
 func (d *Dashboard) GetTemplateByType(t string) []Template {
 	var retval []Template
-	for _, templ := range d.Templating.List {
+	for i, templ := range d.Templating.List {
+		templ.Idx = i
 		if strings.EqualFold(templ.Type, t) {
 			retval = append(retval, templ)
 		}

--- a/lint/model_test.go
+++ b/lint/model_test.go
@@ -86,6 +86,16 @@ func TestParseDashboard(t *testing.T) {
 		assert.Len(t, dashboard.Annotations.List, 1)
 		assert.Equal(t, "v0alpha1", dashboard.APIVersion)
 	})
+
+	t.Run("Templates", func(t *testing.T) {
+		dashboard, err := NewDashboard(sampleDashboard)
+		assert.NoError(t, err)
+		assert.Len(t, dashboard.Templating.List, 4)
+
+		templates := dashboard.GetTemplateByType("query")
+		assert.Len(t, templates, 1)
+		assert.Equal(t, templates[0].Idx, 1)
+	})
 }
 
 func TestParseTemplateValue(t *testing.T) {


### PR DESCRIPTION
the GetTemplateByType function returns a subset of templates, which is useful, but if rules desire to auto-fix the templates, they need to understand the original index, and the resulting subset may have a different length and different set of items.

similar to GetPanels, we preserve the index as a new shadow field that is not marshaled to/from JSON.