### PR TITLE
expose value field from inputs

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -133,6 +133,7 @@ type Input struct {
 	Label    string `json:"label"`
 	Type     string `json:"type"`
 	PluginID string `json:"pluginId"`
+	Value    string `json:"value,omitempty"`
 }
 
 type Datasource struct {


### PR DESCRIPTION
inputs for variables of type=constant will have a value field holding the default value defined for the constant. this is useful to expose when running validation of any kind on constant variables, or for fixing up values.