### PR TITLE
Apply StepSecurity and zizmor fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,5 +17,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      with:
+        persist-credentials: false
     - name: Build
       run: go build ./

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      with:
+        persist-credentials: false
     - name: Test
       run: go test ./...


### PR DESCRIPTION
Securing GH actions as followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).

<details><summary>before</summary>
<p>

```
$ zizmor --gh-token=$(gh auth token) grafana/dashboard-linter
 INFO collect_inputs: zizmor: collected 3 inputs from grafana/dashboard-linter
 INFO audit: zizmor: 🌈 completed .github/workflows/build.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/golangci-lint.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/test.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/build.yml:15:7
   |
15 |       - name: Checkout code
   |  _______-
16 | |       uses: actions/checkout@v2
   | |_______________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/build.yml:4:3
   |
 4 | /   build:
 5 | |     strategy:
...  |
17 | |     - name: Build
18 | |       run: go build ./
   | |                       -
   | |_______________________|
   |                         this job
   |                         default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/golangci-lint.yml:12:9
   |
12 |       - uses: actions/checkout@v2
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:15:7
   |
15 |       - name: Checkout code
   |  _______-
16 | |       uses: actions/checkout@v2
   | |_______________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/test.yml:4:3
   |
 4 | /   test:
 5 | |     strategy:
...  |
17 | |     - name: Test
18 | |       run: go test ./...
   | |                        -
   | |________________________|
   |                          this job
   |                          default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

13 findings (8 suppressed): 0 unknown, 0 informational, 0 low, 5 medium, 0 high
```

</p>
</details> 

<details><summary>after</summary>
<p>

```
$ git remote -v; zizmor --gh-token=$(gh auth token) .
origin	https://github.com/bobdanek/dashboard-linter.git (fetch)
origin	https://github.com/bobdanek/dashboard-linter.git (push)
upstream	https://github.com/grafana/dashboard-linter.git (fetch)
upstream	https://github.com/grafana/dashboard-linter.git (push)
 INFO audit: zizmor: 🌈 completed ./.github/workflows/build.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/golangci-lint.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
No findings to report. Good job!
```

</p>
</details> 

