### PR TITLE
ci: create release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: x64
     steps:
     - name: Checkout code
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Install Go

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ jobs:
     name: lint
     runs-on: x64
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,7 @@ jobs:
 
       # GoReleaser builds the binaries AND creates the GitHub Release with
       # artifacts + checksums attached, driven by the `release:` block in
-      # .goreleaser.yaml. No separate softprops/action-gh-release step is
-      # needed (that pattern is for projects that build artifacts outside
-      # goreleaser, e.g. kubernetes-mixin's `make && zip` flow).
+      # .goreleaser.yaml.
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  goreleaser:
+    runs-on: x64
+    permissions:
+      contents: write  # required to create the GitHub Release and upload artifacts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      # GoReleaser builds the binaries AND creates the GitHub Release with
+      # artifacts + checksums attached, driven by the `release:` block in
+      # .goreleaser.yaml. No separate softprops/action-gh-release step is
+      # needed (that pattern is for projects that build artifacts outside
+      # goreleaser, e.g. kubernetes-mixin's `make && zip` flow).
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,23 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          # Disable setup-go's default caching: on a release that publishes
+          # artifacts, a poisoned cache could be baked into the binaries.
+          # Flagged by zizmor as `cache-poisoning` (HIGH).
+          cache: false
 
-      # GoReleaser builds the binaries AND creates the GitHub Release with
-      # artifacts + checksums attached, driven by the `release:` block in
-      # .goreleaser.yaml.
+      # Validate the tagged commit before publishing. Tag pushes are not
+      # gated by the PR-only build/test/lint workflows, so the release job
+      # itself must run them — otherwise an untested commit could ship.
+      - name: Test
+        run: go test ./...
+
+      - name: Build
+        run: go build ./...
+
+      # GoReleaser builds the release binaries AND creates the GitHub
+      # Release with artifacts + checksums attached, driven by the
+      # `release:` block in .goreleaser.yaml.
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: x64
     steps:
     - name: Checkout code
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Install Go

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,10 +2,6 @@ version: 2
 
 project_name: dashboard-linter
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - id: dashboard-linter
     main: .

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,71 @@
+version: 2
+
+project_name: dashboard-linter
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: dashboard-linter
+    main: .
+    binary: dashboard-linter
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+
+archives:
+  - id: dashboard-linter
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - 'Merge pull request'
+      - 'Merge branch'
+  groups:
+    - title: Dependencies
+      regexp: '^.*?(build|chore)\(deps\)!?:.+$'
+      order: 100
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: grafana
+    name: dashboard-linter
+  draft: false
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
 # Grafana Dashboard Linter
 
-This tool is a command-line application to lint Grafana dashboards for common mistakes, and suggest best practices. To use the linter, run the following install commands:
+This tool is a command-line application to lint Grafana dashboards for common mistakes, and suggest best practices.
+
+## Install
+
+### Prebuilt binaries (recommended)
+
+Download a release archive from the [releases page](https://github.com/grafana/dashboard-linter/releases) and extract the `dashboard-linter` binary onto your `PATH`. Example for Linux on amd64:
+
+```
+VERSION=v0.1.0
+curl -sSfL "https://github.com/grafana/dashboard-linter/releases/download/${VERSION}/dashboard-linter_${VERSION}_linux_amd64.tar.gz" \
+  | tar -xz -C /usr/local/bin dashboard-linter
+dashboard-linter lint dashboard.json
+```
+
+Each release also publishes a `checksums.txt` you can verify against.
+
+### From source
 
 ```
 $ go install github.com/grafana/dashboard-linter@latest
 $ dashboard-linter lint dashboard.json
 ```
+
+Note: `go install ...@<version>` (including `@latest`) currently fails because `go.mod` contains a `replace` directive — Go refuses to install a module with replaces. Build locally with `go build` from a checkout if you need to install from source. The prebuilt binaries above are the supported path for CI.
 
 This tool is a work in progress and it's still very early days. The current capabilities are focused exclusively on dashboards that use a Prometheus data source.
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ Each release also publishes a `checksums.txt` you can verify against.
 
 ### From source
 
+`go install github.com/grafana/dashboard-linter@<version>` does not currently work because `go.mod` contains a `replace` directive — Go refuses to install a module with replaces. Build from a checkout instead:
+
 ```
-$ go install github.com/grafana/dashboard-linter@latest
-$ dashboard-linter lint dashboard.json
+$ git clone https://github.com/grafana/dashboard-linter.git
+$ cd dashboard-linter
+$ go build -o dashboard-linter .
+$ ./dashboard-linter lint dashboard.json
 ```
 
-Note: `go install ...@<version>` (including `@latest`) currently fails because `go.mod` contains a `replace` directive — Go refuses to install a module with replaces. Build locally with `go build` from a checkout if you need to install from source. The prebuilt binaries above are the supported path for CI.
+The prebuilt binaries above are the supported path for CI.
 
 This tool is a work in progress and it's still very early days. The current capabilities are focused exclusively on dashboards that use a Prometheus data source.
 


### PR DESCRIPTION
This PR introduces [GoReleaser](https://github.com/goreleaser/goreleaser-action) to help create GitHub releases and compiled binaries.

The new release workflow will trigger on git tags starting with `v`.

In particular, providing pre-built release binaries addresses the following problem currently seen in main:

```
Downloading github.com/grafana/dashboard-linter@latest
go: downloading github.com/grafana/dashboard-linter v0.0.0-20260505154027-63eab7ddb0ba
go: github.com/grafana/dashboard-linter@latest (in github.com/grafana/dashboard-linter@v0.0.0-20260505154027-63eab7ddb0ba):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```