### PR TITLE
fix: route v2-schema dashboards before unmarshaling legacy struct

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -323,7 +323,26 @@ func (d *Dashboard) Marshal() ([]byte, error) {
 	return json.Marshal(d)
 }
 
+// dashboardEnvelope is a lightweight probe for routing v2 dashboard payloads.
+// Grafana v13+ exports may include legacy top-level compatibility fields
+// (e.g. "templating", "panels") with null values that the classic struct rejects,
+// so we inspect apiVersion before attempting a full unmarshal.
+type dashboardEnvelope struct {
+	APIVersion string          `json:"apiVersion"`
+	Spec       json.RawMessage `json:"spec"`
+}
+
 func NewDashboard(buf []byte) (Dashboard, error) {
+	var env dashboardEnvelope
+	if err := json.Unmarshal(buf, &env); err != nil {
+		return Dashboard{}, err
+	}
+
+	// Route v2 payloads before the classic struct can reject their legacy compat fields.
+	if env.Spec != nil && isV2APIVersion(env.APIVersion) {
+		return newDashboardFromV2(env.Spec, env.APIVersion)
+	}
+
 	var dash Dashboard
 	if err := json.Unmarshal(buf, &dash); err != nil {
 		return dash, err
@@ -331,10 +350,6 @@ func NewDashboard(buf []byte) (Dashboard, error) {
 	// Support kubernetes flavored dashboards
 	if dash.Spec != nil {
 		apiVersion := dash.APIVersion
-		// The v2 schema is structurally different and handled by its own adapter.
-		if isV2APIVersion(apiVersion) {
-			return newDashboardFromV2(dash.Spec, apiVersion)
-		}
 		if apiVersion != "" {
 			if !strings.HasPrefix(apiVersion, "v0") && !strings.HasPrefix(apiVersion, "v1") {
 				return dash, fmt.Errorf("unsupported apiVersion")

--- a/lint/v2_test.go
+++ b/lint/v2_test.go
@@ -132,6 +132,36 @@ func TestParseV2Dashboard(t *testing.T) {
 	})
 }
 
+// Grafana v13 exports of v2-schema dashboards keep a legacy top-level
+// "templating"/"panels" block for older tooling that doesn't understand v2
+// yet. That compatibility block only carries placeholder values (e.g. a
+// `null` "query" field) since the actual variable/panel definitions live
+// under "spec". NewDashboard must route to the v2 adapter without ever
+// unmarshaling that legacy block into the classic (strict) Dashboard struct.
+const v2DashboardWithLegacyCompatBlock = `{
+	"apiVersion": "dashboard.grafana.app/v2",
+	"kind": "Dashboard",
+	"panels": [],
+	"templating": {
+		"list": [
+			{ "current": null, "name": "cluster", "options": null, "query": null, "refresh": 2, "type": "query" },
+			{ "current": null, "name": "namespace", "options": null, "query": null, "refresh": 0, "type": "constant" }
+		]
+	},
+	"spec": {
+		"title": "V2 Test With Legacy Block",
+		"variables": [],
+		"elements": {}
+	}
+}`
+
+func TestParseV2DashboardWithLegacyCompatBlock(t *testing.T) {
+	d, err := NewDashboard([]byte(v2DashboardWithLegacyCompatBlock))
+	require.NoError(t, err)
+	assert.Equal(t, "V2 Test With Legacy Block", d.Title)
+	assert.Equal(t, "dashboard.grafana.app/v2", d.APIVersion)
+}
+
 // ruleHasError reports whether the named rule produced any Error-severity result.
 func ruleHasError(results *ResultSet, rule string) bool {
 	for _, rc := range results.ByRule()[rule] {


### PR DESCRIPTION
Peek into dashboard spec to determine if it is a v2 schema and route it before doing an unmarshal into the legacy `Dashboard` type. This prevents parse failures for dashboards that were created prior to Grafana 13 because they continue to carry forward top-level fields like `.templating` and `.panels`.

Fixes #262 